### PR TITLE
Set msgctxt at pos 0 not directly

### DIFF
--- a/src/Sepia/PoParser.php
+++ b/src/Sepia/PoParser.php
@@ -462,7 +462,7 @@ class PoParser
     public function setEntryContext($msgid, $context = false)
     {
         if ($context) {
-            $this->entries[$msgid]['msgctxt'] = $context;
+            $this->entries[$msgid]['msgctxt'][0] = $context;
         } else {
             unset($this->entries[$msgid]['msgctxt']);
         }


### PR DESCRIPTION
msgctxt is always used as array not as string. If using setEntryContext
only the first character was written to po-file