### PR TITLE
Handle the case of epmty msgid

### DIFF
--- a/src/Sepia/PoParser.php
+++ b/src/Sepia/PoParser.php
@@ -428,7 +428,7 @@ class PoParser
     public function setEntry($msgid, $entry, $createNew = true)
     {
         // In case of new entry
-        if (!isset($this->entries[$msgid])) {
+        if ($msgid && !isset($this->entries[$msgid])) {
 
             if ($createNew==false) {
                 return;


### PR DESCRIPTION
When the msgid is multi-lines, I prefer not to have to do the implode in my code (no need to duplicate this line).
This commit allow a simple
setEntry(NULL, $entry)

and the msgid will be computed at the line 443 (new_msgid) which handle correctly the multi-line case.
