### PR TITLE
Make PoParser::__construct handler param optional

### DIFF
--- a/src/Sepia/PoParser.php
+++ b/src/Sepia/PoParser.php
@@ -81,7 +81,7 @@ class PoParser
     }
 
 
-    public function __construct(InterfaceHandler $handler, $options=array())
+    public function __construct(InterfaceHandler $handler=null, $options=array())
     {
         $this->sourceHandle = $handler;
         $defaultOptions = array(


### PR DESCRIPTION
Having this as a required parameter is unnecessary when it's possible to
pass in a handle to the parse method. The class already copes with
this being null everywhere else it's used.

Closes #53