### PR TITLE
Catalog interface created to increase flexibility

### DIFF
--- a/src/Catalog/Catalog.php
+++ b/src/Catalog/Catalog.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Sepia\PoParser\Catalog;
+
+interface Catalog
+{
+    public function addEntry(Entry $entry);
+
+    public function addHeaders(Header $headers);
+
+    /**
+     * @param string      $msgid
+     * @param string|null $msgctxt
+     */
+    public function removeEntry($msgid, $msgctxt = null);
+
+    /**
+     * @return array
+     */
+    public function getHeaders();
+
+    /**
+     * @return Header
+     */
+    public function getHeader();
+
+    /**
+     * @return Entry[]
+     */
+    public function getEntries();
+
+    /**
+     * @param string      $msgId
+     * @param string|null $context
+     *
+     * @return Entry
+     */
+    public function getEntry($msgId, $context = null);
+}

--- a/src/Catalog/CatalogArray.php
+++ b/src/Catalog/CatalogArray.php
@@ -1,11 +1,8 @@
 <?php
 
-namespace Sepia\PoParser;
+namespace Sepia\PoParser\Catalog;
 
-use Sepia\PoParser\Catalog\Entry;
-use Sepia\PoParser\Catalog\Header;
-
-class Catalog
+class CatalogArray implements Catalog
 {
     /** @var Header */
     protected $headers;
@@ -25,6 +22,9 @@ class Catalog
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addEntry(Entry $entry)
     {
         $key = $this->getEntryHash(
@@ -34,14 +34,16 @@ class Catalog
         $this->entries[$key] = $entry;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addHeaders(Header $headers)
     {
         $this->headers = $headers;
     }
 
     /**
-     * @param string      $msgid
-     * @param string|null $msgctxt
+     * {@inheritdoc}
      */
     public function removeEntry($msgid, $msgctxt = null)
     {
@@ -52,7 +54,7 @@ class Catalog
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getHeaders()
     {
@@ -60,7 +62,7 @@ class Catalog
     }
 
     /**
-     * @return Header
+     * {@inheritdoc}
      */
     public function getHeader()
     {
@@ -68,7 +70,7 @@ class Catalog
     }
 
     /**
-     * @return Entry[]
+     * {@inheritdoc}
      */
     public function getEntries()
     {
@@ -76,10 +78,7 @@ class Catalog
     }
 
     /**
-     * @param string      $msgId
-     * @param string|null $context
-     *
-     * @return Entry|null
+     * {@inheritdoc}
      */
     public function getEntry($msgId, $context = null)
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2,6 +2,8 @@
 
 namespace Sepia\PoParser;
 
+use Sepia\PoParser\Catalog\Catalog;
+use Sepia\PoParser\Catalog\CatalogArray;
 use Sepia\PoParser\Catalog\EntryFactory;
 use Sepia\PoParser\Catalog\Header;
 use Sepia\PoParser\Exception\ParseException;
@@ -98,9 +100,9 @@ class Parser
      * @throws \Exception, \InvalidArgumentException, ParseException
      * @return Catalog
      */
-    public function parse()
+    public function parse(Catalog $catalog = null)
     {
-        $catalog = new Catalog();
+        $catalog = $catalog === null ? new CatalogArray() : $catalog;
         $this->lineNumber = 0;
         $entry = array();
         $this->property = null; // current property

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -2,6 +2,7 @@
 
 namespace Sepia\PoParser;
 
+use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Catalog\Entry;
 use Sepia\PoParser\Catalog\Header;
 

--- a/tests/AbstractFixtureTest.php
+++ b/tests/AbstractFixtureTest.php
@@ -18,7 +18,7 @@ abstract class AbstractFixtureTest extends TestCase
     /**
      * @param string $file
      *
-     * @return \Sepia\PoParser\Catalog
+     * @return \Sepia\PoParser\CatalogArray
      */
     protected function parseFile($file)
     {

--- a/tests/UnitTest/HeaderTest.php
+++ b/tests/UnitTest/HeaderTest.php
@@ -14,9 +14,8 @@ class HeaderTest extends TestCase
         $this->assertEquals(3, $catalog->getHeader()->getPluralFormsCount());
     }
 
-
     /**
-     * @return \Sepia\PoParser\Catalog
+     * @return \Sepia\PoParser\Catalog\Catalog
      */
     protected function parseFile()
     {

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -2,7 +2,9 @@
 
 namespace Sepia\Test;
 
-use Sepia\PoParser\Catalog;
+use Sepia\PoParser\Catalog\Catalog;
+use Sepia\PoParser\Catalog\CatalogArray;
+use Sepia\PoParser\Catalog\EntryFactory;
 use Sepia\PoParser\PoCompiler;
 use Sepia\PoParser\SourceHandler\FileSystem;
 
@@ -11,10 +13,10 @@ class WriteTest extends AbstractFixtureTest
     public function testWrite()
     {
         $faker = \Faker\Factory::create();
-        $catalogSource = new Catalog();
+        $catalogSource = new CatalogArray();
 
         // Normal Entry
-        $entry = Catalog\EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray(array(
             'msgid' => 'string.1',
             'msgstr' => 'translation.1',
             'msgctxt' => 'context.1',
@@ -23,7 +25,7 @@ class WriteTest extends AbstractFixtureTest
             'ccomment' => array('code comment'),
             'flags' => array('1', '2', '3')
         ));
-        $previousEntry = Catalog\EntryFactory::createFromArray(array(
+        $previousEntry = EntryFactory::createFromArray(array(
            'msgid' => 'previous.string.1',
            'msgctxt' => 'previous.context.1'
         ));
@@ -31,7 +33,7 @@ class WriteTest extends AbstractFixtureTest
         $catalogSource->addEntry($entry);
 
         // Obsolete entry
-        $entry = Catalog\EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray(array(
             'msgid' => 'obsolete.1',
             'msgstr' => $faker->paragraph(5),
             'msgctxt' => 'obsolete.context',
@@ -47,9 +49,9 @@ class WriteTest extends AbstractFixtureTest
 
     public function testWritePlurals()
     {
-        $catalogSource = new Catalog();
+        $catalogSource = new CatalogArray();
         // Normal Entry
-        $entry = Catalog\EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray(array(
             'msgid' => 'string.1',
             'msgstr' => 'translation.1',
             'msgstr[0]' => 'translation.plural.0',
@@ -79,7 +81,7 @@ class WriteTest extends AbstractFixtureTest
         $fileHandler->save($compiler->compile($catalog));
     }
 
-    private function assertPoFile(Catalog $catalogSource, Catalog $catalogNew)
+    private function assertPoFile(CatalogArray $catalogSource, Catalog $catalogNew)
     {
         foreach ($catalogSource->getEntries() as $entry) {
             $entryWritten = $catalogNew->getEntry($entry->getMsgId(), $entry->getMsgCtxt());


### PR DESCRIPTION
By offering a Catalog Interface and making Parser::parse() accept it (optionally) instead of creating a fixed implementation (now renamed to CatalogArray), developers can now use their own Catalog's.