### PR TITLE
Modifying headers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
-v5.1.1 (2018-02-04)
-* Parser::parser() optionally accepts a Catalog interface implementation. 
+v5.1.1 (2018-02-10)
+* Header::setHeaders() to allow modifying PO headers.
 
-v5.1 (2018-02-03)
+v5.1 (2018-02-04)
+* Parser::parser() optionally accepts a Catalog interface implementation. 
 * Parser refactor for easier maintenance.
 * Fix parsing comments without space between `#` and text.
 * Fix parsing multiline Headers. 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+v5.1.1 (2018-02-04)
+* Parser::parser() optionally accepts a Catalog interface implementation. 
+
+v5.1 (2018-02-03)
+* Parser refactor for easier maintenance.
+* Fix parsing comments without space between `#` and text.
+* Fix parsing multiline Headers. 
+* Improve Compiler by creating an empty `msgstr[n]` for every plural form defined.
+* Improve parsing headers by offering a base for more granular interpretation.
+
 v5.0 (2018-02-02)
 * Backwards incompatible version! Check [v5 Documentation]() and [Migration guide]() for more information.
 * Refactored to avoid usage issues like [this](https://github.com/raulferras/PHP-po-parser/issues/67), [this](https://github.com/raulferras/PHP-po-parser/issues/62), [this](https://github.com/raulferras/PHP-po-parser/issues/52), [this](https://github.com/raulferras/PHP-po-parser/issues/50)
@@ -12,7 +22,7 @@ v5.0 (2018-02-02)
 * Main deprecations (check [Migration guide]() for more information.):
   - Namespace changed to `Sepia\PoParser`
   - `PoParser` renamed to `Parser`
-  - `parser` method does not return an array anymore, instead a `Catalog` object.
+  - `parser` method does not return an array anymore, instead a `CatalogArray` object.
   - No need for options anymore.
 
 v4.2.2

--- a/src/Catalog/Header.php
+++ b/src/Catalog/Header.php
@@ -8,11 +8,11 @@ class Header
     protected $headers;
 
     /** @var int|null */
-    protected $nPlurals = null;
+    protected $nPlurals;
 
     public function __construct(array $headers = array())
     {
-        $this->headers = $headers;
+        $this->setHeaders($headers);
     }
 
     public function getPluralFormsCount()
@@ -36,6 +36,11 @@ class Header
         $this->nPlurals = isset($matches[1]) ? (int)$matches[1] : 0;
 
         return $this->nPlurals;
+    }
+
+    public function setHeaders(array $headers)
+    {
+        $this->headers = $headers;
     }
 
     /**


### PR DESCRIPTION
Took some bad decisions on 5.0 when designing `Header` class regarding their modification.  
Before implementing these fixes that will incur in backwards incompatibility, I add this `Header::setHeaders` to allow users on v5.1.1 modify them anyway, although in a more ugly way.

Version 6 will contain improvements regarding Headers manipulation.

