### PR TITLE
Version 6: Improvements on header handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+v6 
+* Improvements on Headers API to allow better manipulation:
+** `Catalog` methods `addHeaders` and `getHeader` removed.
+** `Headers` object is the old `Header`.
+** A new class `Header` represeting a single header is created.
+** `Catalog` method `getHeaders` returns a `Headers` object instead of an array of strings.
+** You can retrieve a specific header by its key.
+
 v5.1.1 (2018-02-04)
 * Parser::parser() optionally accepts a Catalog interface implementation. 
 

--- a/src/Catalog/Catalog.php
+++ b/src/Catalog/Catalog.php
@@ -6,7 +6,7 @@ interface Catalog
 {
     public function addEntry(Entry $entry);
 
-    public function addHeaders(Header $headers);
+    public function setHeaders(Headers $headers);
 
     /**
      * @param string      $msgid
@@ -15,14 +15,9 @@ interface Catalog
     public function removeEntry($msgid, $msgctxt = null);
 
     /**
-     * @return array
+     * @return Headers
      */
     public function getHeaders();
-
-    /**
-     * @return Header
-     */
-    public function getHeader();
 
     /**
      * @return Entry[]

--- a/src/Catalog/CatalogArray.php
+++ b/src/Catalog/CatalogArray.php
@@ -4,7 +4,7 @@ namespace Sepia\PoParser\Catalog;
 
 class CatalogArray implements Catalog
 {
-    /** @var Header */
+    /** @var Headers */
     protected $headers;
 
     /** @var array */
@@ -16,7 +16,7 @@ class CatalogArray implements Catalog
     public function __construct(array $entries = array())
     {
         $this->entries = array();
-        $this->headers = new Header();
+        $this->headers = new Headers();
         foreach ($entries as $entry) {
             $this->addEntry($entry);
         }
@@ -37,7 +37,7 @@ class CatalogArray implements Catalog
     /**
      * {@inheritdoc}
      */
-    public function addHeaders(Header $headers)
+    public function setHeaders(Headers $headers)
     {
         $this->headers = $headers;
     }
@@ -57,14 +57,6 @@ class CatalogArray implements Catalog
      * {@inheritdoc}
      */
     public function getHeaders()
-    {
-        return $this->headers->asArray();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeader()
     {
         return $this->headers;
     }

--- a/src/Catalog/Header.php
+++ b/src/Catalog/Header.php
@@ -4,62 +4,35 @@ namespace Sepia\PoParser\Catalog;
 
 class Header
 {
-    /** @var array */
-    protected $headers;
+    /** @var string */
+    protected $id;
 
-    /** @var int|null */
-    protected $nPlurals = null;
+    /** @var string */
+    protected $value;
 
-    public function __construct(array $headers = array())
+    /**
+     * @param string $id
+     * @param string $value
+     */
+    public function __construct($id, $value)
     {
-        $this->headers = $headers;
-    }
-
-    public function getPluralFormsCount()
-    {
-        if ($this->nPlurals !== null) {
-            return $this->nPlurals;
-        }
-
-        $header = $this->getHeaderValue('Plural-Forms');
-        if ($header === null) {
-            $this->nPlurals = 0;
-            return $this->nPlurals;
-        }
-
-        $matches = array();
-        if (preg_match('/nplurals=([0-9]+)/', $header, $matches) !== 1) {
-            $this->nPlurals = 0;
-            return $this->nPlurals;
-        }
-
-        $this->nPlurals = isset($matches[1]) ? (int)$matches[1] : 0;
-
-        return $this->nPlurals;
+        $this->id = $id;
+        $this->value = $value;
     }
 
     /**
-     * @return array
+     * @return string
      */
-    public function asArray()
+    public function getId()
     {
-        return $this->headers;
+        return $this->id;
     }
 
     /**
-     * @param string $headerName
-     *
-     * @return string|null
+     * @return string
      */
-    protected function getHeaderValue($headerName)
+    public function getValue()
     {
-        $header = array_values(array_filter(
-            $this->headers,
-            function ($string) use ($headerName) {
-                return preg_match('/'.$headerName.':(.*)/i', $string) == 1;
-            }
-        ));
-
-        return count($header) ? $header[0] : null;
+        return $this->value;
     }
 }

--- a/src/Catalog/Headers.php
+++ b/src/Catalog/Headers.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Sepia\PoParser\Catalog;
+
+class Headers
+{
+    /** @var Header[] */
+    protected $headers;
+
+    /** @var int|null */
+    protected $nPlurals;
+
+    /**
+     * Headers constructor.
+     *
+     * @param Header[] $headers
+     */
+    public function __construct(array $headers = array())
+    {
+        foreach ($headers as $header) {
+            $this->headers[$header->getId()] = $header;
+        }
+    }
+
+    /**
+     * @param string $headerKey
+     *
+     * @return bool
+     */
+    public function has($headerKey)
+    {
+        return isset($this->headers[$headerKey]);
+    }
+
+    /**
+     * @param string $headerKey
+     *
+     * @return Header|null
+     */
+    public function get($headerKey)
+    {
+        if (!$this->has($headerKey)) {
+            return null;
+        }
+
+        return $this->headers[$headerKey];
+    }
+
+    /**
+     * @return Header[]
+     */
+    public function all()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @param Header $header
+     */
+    public function set(Header $header)
+    {
+        $this->headers[$header->getId()] = $header;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPluralFormsCount()
+    {
+        if ($this->nPlurals !== null) {
+            return $this->nPlurals;
+        }
+
+        $key = 'Plural-Forms';
+        if (!$this->has($key)) {
+            $this->nPlurals = 0;
+            return $this->nPlurals;
+        }
+
+        $header = $this->get('Plural-Forms');
+
+        $matches = array();
+        if (preg_match('/nplurals=([0-9]+)/', $header->getValue(), $matches) !== 1) {
+            $this->nPlurals = 0;
+            return $this->nPlurals;
+        }
+
+        $this->nPlurals = isset($matches[1]) ? (int)$matches[1] : 0;
+
+        return $this->nPlurals;
+    }
+
+    /**
+     * @param string $headerName
+     *
+     * @return string|null
+     */
+/*    protected function getHeaderValue($headerName)
+    {
+        $header = array_values(array_filter(
+            $this->headers,
+            function ($string) use ($headerName) {
+                return preg_match('/'.$headerName.':(.*)/i', $string) == 1;
+            }
+        ));
+
+        return count($header) ? $header[0] : null;
+    }
+*/
+}

--- a/src/Catalog/Headers.php
+++ b/src/Catalog/Headers.php
@@ -63,6 +63,20 @@ class Headers
     }
 
     /**
+     * Remove a Header.
+     *
+     * @param string $headerKey
+     */
+    public function remove($headerKey)
+    {
+        if (!$this->has($headerKey)) {
+            return;
+        }
+
+        unset($this->headers[$headerKey]);
+    }
+
+    /**
      * @return int
      */
     public function getPluralFormsCount()

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -6,6 +6,8 @@ use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Catalog\CatalogArray;
 use Sepia\PoParser\Catalog\EntryFactory;
 use Sepia\PoParser\Catalog\Header;
+use Sepia\PoParser\Catalog\HeaderFactory;
+use Sepia\PoParser\Catalog\Headers;
 use Sepia\PoParser\Exception\ParseException;
 use Sepia\PoParser\SourceHandler\FileSystem;
 use Sepia\PoParser\SourceHandler\SourceHandler;
@@ -121,7 +123,7 @@ class Parser
             if ($this->shouldCloseEntry($line, $entry)) {
                 if (!$headersFound && $this->isHeader($entry)) {
                     $headersFound = true;
-                    $catalog->addHeaders(
+                    $catalog->setHeaders(
                         $this->parseHeaders($entry['msgstr'])
                     );
                 } else {
@@ -317,13 +319,24 @@ class Parser
     /**
      * @param string $msgstr
      *
-     * @return Header
+     * @return Headers
      */
     protected function parseHeaders($msgstr)
     {
-        $headers = array_filter(explode('\\n', $msgstr));
+        $rawHeaders = array_filter(explode('\\n', $msgstr));
+        $headers = array();
 
-        return new Header($headers);
+        foreach ($rawHeaders as $rawHeader) {
+            $tokens = explode(':', $rawHeader, 2);
+            if (count($tokens) !== 2) {
+                continue;
+            }
+
+            list($id, $value) = $tokens;
+            $headers[] = new Header($id, trim($value));
+        }
+
+        return new Headers($headers);
     }
 
     /**

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -4,7 +4,7 @@ namespace Sepia\PoParser;
 
 use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Catalog\Entry;
-use Sepia\PoParser\Catalog\Header;
+use Sepia\PoParser\Catalog\Headers;
 
 class PoCompiler
 {
@@ -40,11 +40,11 @@ class PoCompiler
     {
         $output = '';
 
-        if (count($catalog->getHeaders()) > 0) {
+        if (count($catalog->getHeaders()->all()) > 0) {
             $output .= 'msgid ""'.$this->eol();
             $output .= 'msgstr ""'.$this->eol();
-            foreach ($catalog->getHeaders() as $header) {
-                $output .= $header.$this->eol();
+            foreach ($catalog->getHeaders()->all() as $header) {
+                $output .= $header->getId().': '.$header->getValue().$this->eol();
             }
             $output .= $this->eol();
         }
@@ -69,7 +69,7 @@ class PoCompiler
             $output .= $this->buildContext($entry);
             $output .= $this->buildMsgId($entry);
             $output .= $this->buildMsgIdPlural($entry);
-            $output .= $this->buildMsgStr($entry, $catalog->getHeader());
+            $output .= $this->buildMsgStr($entry, $catalog->getHeaders());
 
 
             $counter++;
@@ -183,7 +183,7 @@ class PoCompiler
         return $this->buildProperty('msgid', $entry->getMsgId(), $entry->isObsolete());
     }
 
-    protected function buildMsgStr(Entry $entry, Header $headers)
+    protected function buildMsgStr(Entry $entry, Headers $headers)
     {
         $value = $entry->getMsgStr();
         $plurals = $entry->getMsgStrPlurals();

--- a/tests/UnitTest/HeaderTest.php
+++ b/tests/UnitTest/HeaderTest.php
@@ -11,7 +11,7 @@ class HeaderTest extends TestCase
     {
         $catalog = $this->parseFile();
 
-        $this->assertEquals(3, $catalog->getHeader()->getPluralFormsCount());
+        $this->assertEquals(3, $catalog->getHeaders()->getPluralFormsCount());
     }
 
     /**

--- a/tests/UnitTest/ReadPoTest.php
+++ b/tests/UnitTest/ReadPoTest.php
@@ -183,14 +183,14 @@ class ReadPoTest extends AbstractFixtureTest
     {
         $catalog = $this->parseFile('basicHeadersMultiline.po');
         $this->assertCount(1, $catalog->getEntries());
-        $this->assertCount(3,$catalog->getHeaders());
+        $this->assertCount(3, $catalog->getHeaders()->all());
     }
 
     public function testFileWithOnlyHeaders()
     {
         $catalog = $this->parseFile('basicOnlyHeader.po');
         $this->assertCount(0, $catalog->getEntries());
-        $this->assertGreaterThanOrEqual(1, count($catalog->getHeaders()));
+        $this->assertGreaterThanOrEqual(1, count($catalog->getHeaders()->all()));
     }
 
     public function testNoBlankLinesSeparatingEntries()


### PR DESCRIPTION
This PR brings better handling of headers by:
- Allowing to get a specific header by its key.
- Allow setting a single header.
- Remove a specific header by its key.

Sadly I did a mistake designing v5.0 API and I needed to modify it for these changes, so I'm forced to push a new major version.