### PR TITLE
Prevent splitting multibyte characters across lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "issues": "https://github.com/raulferras/PHP-po-parser/issues"
   },
   "require": {
-    "php": ">=5.3"
+    "php": ">=5.3",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": ">=5.3",
-    "ext-mbstring": "*"
+    "symfony/polyfill-mbstring": "^1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.0",

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -270,8 +270,12 @@ class PoCompiler
      */
     private function wrapString($value)
     {
-        if (strlen($value) > $this->wrappingColumn) {
-            $tokens = str_split($value, $this->wrappingColumn);
+        $length = mb_strlen($value);
+        if ($length > $this->wrappingColumn) {
+            $tokens = array();
+            for ($i = 0; $i < $length; $i += $this->wrappingColumn) {
+                $tokens[] = mb_substr($value, $i, $this->wrappingColumn);
+            }
         } else {
             $tokens = array($value);
         }

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -73,6 +73,10 @@ class WriteTest extends AbstractFixtureTest
 
     public function testWriteMultibyte()
     {
+        // Make sure that encoding is set to UTF-8 for this test
+        $mbEncoding = mb_internal_encoding();
+        mb_internal_encoding('UTF-8');
+
         $catalogSource = new CatalogArray();
         // Normal Entry
         $entry = EntryFactory::createFromArray(array(
@@ -93,6 +97,9 @@ class WriteTest extends AbstractFixtureTest
         fgets($fh); // ignore line 2
         $this->assertEquals("\"multibyte.translá\"\n", fgets($fh));
         $this->assertEquals("\"tion.1\"\n", fgets($fh));
+
+        // Revert encoding to previous setting
+        mb_internal_encoding($mbEncoding);
     }
 
     public function testDoubleEscaped()


### PR DESCRIPTION
Count wrapping column in characters rather than bytes to fix #79
