### PR TITLE
Initialize pluralization strings to ensure array

### DIFF
--- a/src/Catalog/Entry.php
+++ b/src/Catalog/Entry.php
@@ -45,6 +45,7 @@ class Entry
     {
         $this->msgId = $msgId;
         $this->msgStr = $msgStr;
+        $this->msgStrPlurals = array();
         $this->flags = array();
         $this->translatorComments = array();
         $this->developerComments = array();
@@ -244,7 +245,7 @@ class Entry
      */
     public function isPlural()
     {
-        return $this->getMsgIdPlural() !== null || $this->getMsgStrPlurals() !== null;
+        return $this->getMsgIdPlural() !== null || count($this->getMsgStrPlurals()) > 0;
     }
 
     /**

--- a/tests/UnitTest/ReadPoTest.php
+++ b/tests/UnitTest/ReadPoTest.php
@@ -96,7 +96,17 @@ class ReadPoTest extends AbstractFixtureTest
             $entry->getMsgStrPlurals()
         );
     }
-    
+
+    public function testEmptyPlurals()
+    {
+        $catalog = $this->parseFile('plurals.po');
+
+        $entry = $catalog->getEntry('Light');
+        $this->assertNotNull($entry);
+        $this->assertNull($entry->getMsgIdPlural());
+        $this->assertEmpty($entry->getMsgStrPlurals());
+    }
+
     public function testFlags()
     {
         $catalog = $this->parseFile('multiflags.po');


### PR DESCRIPTION
When using this library I encountered a few bugs caused by `msgStrPlurals` being `null` although documented as an array. This leads to confusion and the need to handle the null case in all places.

This will also make the behavior consistent with the comment fields etc.

Btw thanks for this lib :)