### PR TITLE
Bugfix for Issue #89

### DIFF
--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -199,7 +199,7 @@ class PoCompiler
             $maxIterations = max($nPlurals, $pluralsFound);
             for ($i = 0; $i < $maxIterations; $i++) {
                 $value = isset($plurals[$i]) ? $plurals[$i] : '';
-                $output .= $entry->isObsolete() ? self::TOKEN_OBSOLETE . ' ' : '';
+                $output .= $entry->isObsolete() ? self::TOKEN_OBSOLETE : '';
                 $output .= 'msgstr['.$i.'] '.$this->cleanExport($value).$this->eol();
             }
 
@@ -222,7 +222,7 @@ class PoCompiler
         }
 
         $output = '';
-        $output .= $entry->isObsolete() ? self::TOKEN_OBSOLETE . ' ' : '';
+        $output .= $entry->isObsolete() ? self::TOKEN_OBSOLETE : '';
         $output .= 'msgid_plural '.$this->cleanExport($value).$this->eol();
         return $output;
     }

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -199,6 +199,7 @@ class PoCompiler
             $maxIterations = max($nPlurals, $pluralsFound);
             for ($i = 0; $i < $maxIterations; $i++) {
                 $value = isset($plurals[$i]) ? $plurals[$i] : '';
+                $output .= $entry->isObsolete() ? self::TOKEN_OBSOLETE . ' ' : '';
                 $output .= 'msgstr['.$i.'] '.$this->cleanExport($value).$this->eol();
             }
 
@@ -220,7 +221,10 @@ class PoCompiler
             return '';
         }
 
-        return 'msgid_plural '.$this->cleanExport($value).$this->eol();
+        $output = '';
+        $output .= $entry->isObsolete() ? self::TOKEN_OBSOLETE . ' ' : '';
+        $output .= 'msgid_plural '.$this->cleanExport($value).$this->eol();
+        return $output;
     }
 
     protected function buildProperty($property, $value, $obsolete = false)

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -126,6 +126,46 @@ class WriteTest extends AbstractFixtureTest
         $this->assertNotNull($catalog->getEntry('a\nb\nc'));
     }
 
+    public function testWriteObsoletePlural()
+    {
+
+        $catalogSource = new CatalogArray();
+
+        // Obsolete entry
+        $entry = EntryFactory::createFromArray(array(
+            'msgid' => '%d obsolete string',
+            'msgid_plural' => '%d obsolete strings',
+            'msgstr' => 'translation.2',
+            'msgstr[0]' => 'translation.plural.0',
+            'msgstr[1]' => 'translation.plural.1',
+            'msgstr[2]' => 'translation.plural.2',
+            'reference' => array('src/views/forms.php:45'),
+            'tcomment' => array('translator comment'),
+            'ccomment' => array('code comment'),
+            'flags' => array('fuzzy'),
+            'obsolete' => true
+        ));
+
+        $catalogSource->addEntry($entry);
+
+        $this->saveCatalog($catalogSource);
+
+        $written_contents = file_get_contents($this->resourcesPath.'temp.po');
+
+        $eol = "\n";
+
+        $expected_contents = '' .
+            '#, fuzzy' . $eol .
+            '#~ msgid "%d obsolete string"' . $eol .
+            '#~ msgid_plural "%d obsolete strings"' . $eol .
+            '#~ msgstr[0] "translation.plural.0"' . $eol .
+            '#~ msgstr[1] "translation.plural.1"' . $eol .
+            '#~ msgstr[2] "translation.plural.2"' . $eol;
+
+        $this->assertEquals($expected_contents, $written_contents);
+
+    }
+
     /**
      * @throws \Exception
      */


### PR DESCRIPTION
Fixes the error on compiling obsolete plurals.

`msgid_plural` and `msg_str[]` are missing the obsolete prefix (`#~`)

This produces broken .po-files:

```
#~ msgid "Mutter"
msgid_plural "Mütter"
msgstr[0] "мать"
msgstr[1] "матери"
msgstr[2] "матери"
```
