### PR TITLE
Test/Fix for Issue91

### DIFF
--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -263,28 +263,8 @@ class PoCompiler
         return "$quote$string$quote";
     }
 
-//    /**
-//     * @param string $value
-//     *
-//     * @return array
-//     */
-//    private function wrapStringBuggy($value)
-//    {
-//        $length = mb_strlen($value);
-//        if ($length > $this->wrappingColumn) {
-//            $tokens = array();
-//            for ($i = 0; $i < $length; $i += $this->wrappingColumn) {
-//                $tokens[] = mb_substr($value, $i, $this->wrappingColumn);
-//            }
-//        } else {
-//            $tokens = array($value);
-//        }
-//
-//        return $tokens;
-//    }
-
     /**
-     * @param $value
+     * @param string $value
      * @return array
      */
     private function wrapString($value)

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -263,23 +263,33 @@ class PoCompiler
         return "$quote$string$quote";
     }
 
+//    /**
+//     * @param string $value
+//     *
+//     * @return array
+//     */
+//    private function wrapStringBuggy($value)
+//    {
+//        $length = mb_strlen($value);
+//        if ($length > $this->wrappingColumn) {
+//            $tokens = array();
+//            for ($i = 0; $i < $length; $i += $this->wrappingColumn) {
+//                $tokens[] = mb_substr($value, $i, $this->wrappingColumn);
+//            }
+//        } else {
+//            $tokens = array($value);
+//        }
+//
+//        return $tokens;
+//    }
+
     /**
-     * @param string $value
-     *
+     * @param $value
      * @return array
      */
     private function wrapString($value)
     {
-        $length = mb_strlen($value);
-        if ($length > $this->wrappingColumn) {
-            $tokens = array();
-            for ($i = 0; $i < $length; $i += $this->wrappingColumn) {
-                $tokens[] = mb_substr($value, $i, $this->wrappingColumn);
-            }
-        } else {
-            $tokens = array($value);
-        }
-
-        return $tokens;
+        $wrapped = wordwrap($value, $this->wrappingColumn, " \n");
+        return explode("\n", $wrapped);
     }
 }

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -126,6 +126,36 @@ class WriteTest extends AbstractFixtureTest
         $this->assertNotNull($catalog->getEntry('a\nb\nc'));
     }
 
+    public function testWrapping()
+    {
+        $catalogSource = new CatalogArray();
+        // Normal Entry
+        $entry = EntryFactory::createFromArray(array(
+            'msgid' => 'Hello everybody, Hello ladies and gentlemen..... this is a line with more than \"eighty\" chars. And char 80+81 is an escaped double quote.',
+            'msgstr' => 'quotes'
+        ));
+        $catalogSource->addEntry($entry);
+
+        $this->saveCatalog($catalogSource);
+
+        $written_contents = file_get_contents($this->resourcesPath.'temp.po');
+
+        $this->assertNotEmpty($written_contents);
+
+        $eol = "\n";
+
+        /**
+         * This is a buggy output and should not occur
+         */
+        $expected = '' .
+            'msgid ""' . $eol .
+            '"Hello everybody, Hello ladies and gentlemen..... this is a line with more than \"' . $eol .
+            '"\"eighty\" chars. And char 80+81 is an escaped double quote."' . $eol .
+            'msgstr "quotes"' . $eol;
+
+        $this->assertNotEquals($expected, $written_contents, 'Wrapping should not split any escape sequence');
+    }
+
     /**
      * @throws \Exception
      */

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -95,7 +95,7 @@ class WriteTest extends AbstractFixtureTest
 
         $entry = EntryFactory::createFromArray(array(
             'msgid' => 'a\nb\nc',
-            'msgstr' => "linebreaks"
+            'msgstr' => 'linebreaks'
         ));
         $catalogSource->addEntry($entry);
 
@@ -242,7 +242,11 @@ class WriteTest extends AbstractFixtureTest
 
         $catalogSource->addEntry($entry);
 
-        $this->saveCatalog($catalogSource);
+        try {
+            $this->saveCatalog($catalogSource);
+        } catch (Exception $e) {
+            $this->fail('Cannot save catalog');
+        }
 
         $written_contents = file_get_contents($this->resourcesPath.'temp.po');
 
@@ -261,6 +265,8 @@ class WriteTest extends AbstractFixtureTest
     }
 
     /**
+     * @param Catalog $catalog
+     * @param int $wrappingColumn
      * @throws Exception
      */
     protected function saveCatalog(Catalog $catalog, $wrappingColumn = 80)

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -73,40 +73,6 @@ class WriteTest extends AbstractFixtureTest
         $this->assertCount(3, $entry->getMsgStrPlurals());
     }
 
-// This test fails now because of migrating the wrapString-Method to wordwrap.
-// From now on, wrapping happens never in the middle of word. So this test is obsolete.
-//
-//    public function testWriteMultibyte()
-//    {
-//        // Make sure that encoding is set to UTF-8 for this test
-//        $mbEncoding = mb_internal_encoding();
-//        mb_internal_encoding('UTF-8');
-//
-//        $catalogSource = new CatalogArray();
-//        // Normal Entry
-//        $entry = EntryFactory::createFromArray(array(
-//            'msgid' => 'string.1',
-//            'msgstr' => 'multibyte.translátion.1'
-//        ));
-//
-//        $catalogSource->addEntry($entry);
-//
-//        $this->saveCatalog($catalogSource, 17);
-//        $catalog = $this->parseFile('temp.po');
-//        $entry = $catalog->getEntry('string.1');
-//        $this->assertEquals('multibyte.translátion.1', $entry->getMsgStr());
-//
-//        // Actual lines in PO file should not be split on multibyte character
-//        $fh = fopen($this->resourcesPath . 'temp.po', 'r');
-//        fgets($fh); // ignore line 1
-//        fgets($fh); // ignore line 2
-//        $this->assertEquals("\"multibyte.translá\"\n", fgets($fh));
-//        $this->assertEquals("\"tion.1\"\n", fgets($fh));
-//
-//        // Revert encoding to previous setting
-//        mb_internal_encoding($mbEncoding);
-//    }
-
     public function testDoubleEscaped()
     {
         $catalogSource = new CatalogArray();

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -2,8 +2,10 @@
 
 namespace Sepia\Test;
 
+use Exception;
 use Faker\Factory;
 use ReflectionClass;
+use ReflectionException;
 use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Catalog\CatalogArray;
 use Sepia\PoParser\Catalog\EntryFactory;
@@ -43,7 +45,11 @@ class WriteTest extends AbstractFixtureTest
         ));
         $catalogSource->addEntry($entry);
 
-        $this->saveCatalog($catalogSource);
+        try {
+            $this->saveCatalog($catalogSource);
+        } catch (Exception $e) {
+            $this->fail('Cannot save catalog.');
+        }
 
         $catalog = $this->parseFile('temp.po');
         $this->assertPoFile($catalogSource, $catalog);
@@ -67,7 +73,11 @@ class WriteTest extends AbstractFixtureTest
 
         $catalogSource->addEntry($entry);
 
-        $this->saveCatalog($catalogSource);
+        try {
+            $this->saveCatalog($catalogSource);
+        } catch (Exception $e) {
+            $this->fail('Cannot save catalog.');
+        }
         $catalog = $this->parseFile('temp.po');
         $entry = $catalog->getEntry('string.1');
         $this->assertCount(3, $entry->getMsgStrPlurals());
@@ -89,7 +99,11 @@ class WriteTest extends AbstractFixtureTest
         ));
         $catalogSource->addEntry($entry);
 
-        $this->saveCatalog($catalogSource);
+        try {
+            $this->saveCatalog($catalogSource);
+        } catch (Exception $e) {
+            $this->fail('Cannot save catalog.');
+        }
 
         $catalog = $this->parseFile('temp.po');
         $this->assertCount(2, $catalog->getEntries());
@@ -111,58 +125,58 @@ class WriteTest extends AbstractFixtureTest
             $method->setAccessible(true);
             $compiler = new PoCompiler();
 
-        } catch (\ReflectionException $e) {
+        } catch (ReflectionException $e) {
             $this->fail('Method wrapString not found in PoCompiler');
             return;
         }
 
-        $tests = [
+        $tests = array(
             // Test Multibyte Wrap (char 80)
-            [
+            array(
                 'value' => 'Hello everybody, Hello ladies and gentlemen... this is a multibyte translation á with a multibyte beginning at char 80.',
-                'assert' => [
+                'assert' => array(
                     'Hello everybody, Hello ladies and gentlemen... this is a multibyte translation ',
                     'á with a multibyte beginning at char 80.'
-                ],
-            ],
+                ),
+            ),
             // Test Multibyte Wrap (char 79)
-            [
+            array(
                 'value' => 'Hello everybody, Hello ladies and gentlemen.. this is a multibyte translation á with multibytes beginning at char 79.',
-                'assert' => [
+                'assert' => array(
                     'Hello everybody, Hello ladies and gentlemen.. this is a multibyte translation á ',
                     'with multibytes beginning at char 79.'
-                ],
-            ],
+                ),
+            ),
             // Test Escape-Sequence Wrap (char 80+81)
-            [
+            array(
                 'value' => 'Hello everybody, Hello ladies and gentlemen..... this is a line with more than \"eighty\" chars. And char 80+81 is an escaped double quote.',
-                'assert' => [
+                'assert' => array(
                     'Hello everybody, Hello ladies and gentlemen..... this is a line with more than ',
                     '\"eighty\" chars. And char 80+81 is an escaped double quote.'
-                ],
-            ],
+                ),
+            ),
             // Test Escape-Sequence Wrap (char 79+80)
-            [
+            array(
                 'value' => 'Hello everybody, Hello ladies and gentlemen.... this is a line with more than \"eighty\" chars. And char 79+80 is an escaped double quote.',
-                'assert' => [
+                'assert' => array(
                     'Hello everybody, Hello ladies and gentlemen.... this is a line with more than ',
                     '\"eighty\" chars. And char 79+80 is an escaped double quote.'
-                ],
-            ],
+                ),
+            ),
             // Test Escaped Line-break
-            [
+            array(
                 'value' => 'Hello everybody, \\nHello ladies and gentlemen.',
-                'assert' => [
+                'assert' => array(
                     'Hello everybody, \\nHello ladies and gentlemen.'
-                ],
-            ],
+                ),
+            ),
 
-        ];
+        );
 
         // Test if the wrapping equals the assert
         foreach($tests as $test) {
             // Test the private method
-            $res = $method->invokeArgs($compiler, [$test['value']]);
+            $res = $method->invokeArgs($compiler, array($test['value']));
             $this->assertEquals($test['assert'], $res);
         }
 
@@ -187,7 +201,7 @@ class WriteTest extends AbstractFixtureTest
         unset($test);
         try {
             $this->saveCatalog($catalogSource);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->fail('Cannot save catalog');
         }
 
@@ -208,7 +222,7 @@ class WriteTest extends AbstractFixtureTest
 
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     protected function saveCatalog(Catalog $catalog, $wrappingColumn = 80)
     {
@@ -245,8 +259,8 @@ class WriteTest extends AbstractFixtureTest
     {
         parent::tearDown();
 
-        if (file_exists($this->resourcesPath.'temp.po')) {
+        //if (file_exists($this->resourcesPath.'temp.po')) {
         //    unlink($this->resourcesPath.'temp.po');
-        }
+        //}
     }
 }


### PR DESCRIPTION
Like promised before i wrote a test that will fail because of issue #91. Wrapping destroys the line because it splits an escape sequence.

I recommend a change in the wrapping-method. Let's use wordwrap https://www.php.net/manual/de/function.wordwrap.php with cut=false.