### PR TITLE
Modernise code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^4.0",
-    "phpunit/phpunit": "^10.0"
+    "phpunit/phpunit": "^12.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,12 @@
     "issues": "https://github.com/raulferras/PHP-po-parser/issues"
   },
   "require": {
-    "php": ">=5.3",
+    "php": "^8.3.0 || ^8.4.0 || ^8.5.0",
     "symfony/polyfill-mbstring": "^1"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "^2.0",
-    "fzaninotto/faker": "^1.7",
-    "phpunit/phpunit": "^5"
+    "squizlabs/php_codesniffer": "^4.0",
+    "phpunit/phpunit": "^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -56,8 +56,8 @@ $entry = new Entry('welcome.user', 'Welcome User!');
 $catalog->setEntry($entry);
 
 // You can also modify other entry attributes as translator comments, code comments, flags...
-$entry->setTranslatorComments(array('This is shown whenever a new user registers in the website'));
-$entry->setFlags(array('fuzzy', 'php-code'));
+$entry->setTranslatorComments(['This is shown whenever a new user registers in the website']);
+$entry->setFlags(['fuzzy', 'php-code']);
 ```
 
 ## Save Changes back to a file

--- a/src/Catalog/Catalog.php
+++ b/src/Catalog/Catalog.php
@@ -4,36 +4,20 @@ namespace Sepia\PoParser\Catalog;
 
 interface Catalog
 {
-    public function addEntry(Entry $entry);
+    public function addEntry(Entry $entry): void;
 
-    public function addHeaders(Header $headers);
+    public function addHeaders(Header $headers): void;
 
-    /**
-     * @param string      $msgid
-     * @param string|null $msgctxt
-     */
-    public function removeEntry($msgid, $msgctxt = null);
+    public function removeEntry(string $msgid, ?string $msgctxt = null): void;
 
-    /**
-     * @return array
-     */
-    public function getHeaders();
+    public function getHeaders(): array;
 
-    /**
-     * @return Header
-     */
-    public function getHeader();
+    public function getHeader(): Header;
 
     /**
      * @return Entry[]
      */
-    public function getEntries();
+    public function getEntries(): array;
 
-    /**
-     * @param string      $msgId
-     * @param string|null $context
-     *
-     * @return Entry|null
-     */
-    public function getEntry($msgId, $context = null);
+    public function getEntry(string $msgId, ?string $context = null): ?Entry;
 }

--- a/src/Catalog/Catalog.php
+++ b/src/Catalog/Catalog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\Catalog;
 
 interface Catalog

--- a/src/Catalog/CatalogArray.php
+++ b/src/Catalog/CatalogArray.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\Catalog;
 
 class CatalogArray implements Catalog
@@ -12,7 +14,7 @@ class CatalogArray implements Catalog
     {
         $this->headers = new Header();
         $this->entries = [];
-        
+
         foreach ($entries as $entry) {
             $this->addEntry($entry);
         }

--- a/src/Catalog/CatalogArray.php
+++ b/src/Catalog/CatalogArray.php
@@ -4,28 +4,21 @@ namespace Sepia\PoParser\Catalog;
 
 class CatalogArray implements Catalog
 {
-    /** @var Header */
-    protected $headers;
+    /** @var array<string, Entry> */
+    protected array $entries;
+    protected Header $headers;
 
-    /** @var array */
-    protected $entries;
-
-    /**
-     * @param Entry[] $entries
-     */
-    public function __construct(array $entries = array())
+    public function __construct(array $entries = [])
     {
-        $this->entries = array();
         $this->headers = new Header();
+        $this->entries = [];
+        
         foreach ($entries as $entry) {
             $this->addEntry($entry);
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addEntry(Entry $entry)
+    public function addEntry(Entry $entry): void
     {
         $key = $this->getEntryHash(
             $entry->getMsgId(),
@@ -34,18 +27,12 @@ class CatalogArray implements Catalog
         $this->entries[$key] = $entry;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addHeaders(Header $headers)
+    public function addHeaders(Header $headers): void
     {
         $this->headers = $headers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeEntry($msgid, $msgctxt = null)
+    public function removeEntry(string $msgid, ?string $msgctxt = null): void
     {
         $key = $this->getEntryHash($msgid, $msgctxt);
         if (isset($this->entries[$key])) {
@@ -53,34 +40,22 @@ class CatalogArray implements Catalog
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers->asArray();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeader()
+    public function getHeader(): Header
     {
         return $this->headers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getEntries()
+    public function getEntries(): array
     {
         return $this->entries;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getEntry($msgId, $context = null)
+    public function getEntry(string $msgId, ?string $context = null): ?Entry
     {
         $key = $this->getEntryHash($msgId, $context);
         if (!isset($this->entries[$key])) {
@@ -90,13 +65,7 @@ class CatalogArray implements Catalog
         return $this->entries[$key];
     }
 
-    /**
-     * @param string      $msgId
-     * @param string|null $context
-     *
-     * @return string
-     */
-    private function getEntryHash($msgId, $context = null)
+    private function getEntryHash(string $msgId, ?string $context = null): string
     {
         return \md5($msgId.$context);
     }

--- a/src/Catalog/Entry.php
+++ b/src/Catalog/Entry.php
@@ -4,278 +4,176 @@ namespace Sepia\PoParser\Catalog;
 
 class Entry
 {
-    /** @var string */
-    protected $msgId;
+    protected string $msgId;
 
-    /** @var string|null */
-    protected $msgStr;
+    protected ?string $msgStr;
 
-    /** @var string|null */
-    protected $msgIdPlural;
+    protected ?string $msgIdPlural;
 
-    /** @var string[] */
-    protected $msgStrPlurals;
+    protected array $msgStrPlurals;
 
-    /** @var string|null */
-    protected $msgCtxt;
+    protected ?string $msgCtxt;
 
-    /** @var Entry|null */
-    protected $previousEntry;
+    protected ?Entry $previousEntry;
 
-    /** @var bool|null */
-    protected $obsolete;
+    protected ?bool $obsolete;
 
-    /** @var array */
-    protected $flags;
+    protected array $flags;
 
-    /** @var array */
-    protected $translatorComments;
+    protected array $translatorComments;
 
-    /** @var array */
-    protected $developerComments;
+    protected array $developerComments;
 
-    /** @var array */
-    protected $reference;
+    protected array $reference;
 
-    /**
-     * @param string $msgId
-     * @param string|null $msgStr
-     */
-    public function __construct($msgId, $msgStr = null)
+    public function __construct(string $msgId, ?string $msgStr = null)
     {
         $this->msgId = $msgId;
         $this->msgStr = $msgStr;
-        $this->msgStrPlurals = array();
-        $this->flags = array();
-        $this->translatorComments = array();
-        $this->developerComments = array();
-        $this->reference = array();
+        $this->msgIdPlural = null;
+        $this->msgStrPlurals = [];
+        $this->msgCtxt = null;
+        $this->previousEntry = null;
+        $this->obsolete = null;
+        $this->flags = [];
+        $this->translatorComments = [];
+        $this->developerComments = [];
+        $this->reference = [];
     }
 
-    /**
-     * @param string $msgId
-     *
-     * @return Entry
-     */
-    public function setMsgId($msgId)
+    public function setMsgId(string $msgId): self
     {
         $this->msgId = $msgId;
 
         return $this;
     }
 
-    /**
-     * @param string|null $msgStr
-     *
-     * @return Entry
-     */
-    public function setMsgStr($msgStr)
+    public function setMsgStr(?string $msgStr): self
     {
         $this->msgStr = $msgStr;
 
         return $this;
     }
 
-    /**
-     * @param string|null $msgIdPlural
-     *
-     * @return Entry
-     */
-    public function setMsgIdPlural($msgIdPlural)
+    public function setMsgIdPlural(?string $msgIdPlural): self
     {
         $this->msgIdPlural = $msgIdPlural;
 
         return $this;
     }
 
-    /**
-     * @param string|null $msgCtxt
-     *
-     * @return Entry
-     */
-    public function setMsgCtxt($msgCtxt)
+    public function setMsgCtxt(?string $msgCtxt): self
     {
         $this->msgCtxt = $msgCtxt;
 
         return $this;
     }
 
-    /**
-     * @param null|Entry $previousEntry
-     *
-     * @return Entry
-     */
-    public function setPreviousEntry($previousEntry)
+    public function setPreviousEntry(?Entry $previousEntry): self
     {
         $this->previousEntry = $previousEntry;
 
         return $this;
     }
 
-    /**
-     * @param bool|null $obsolete
-     *
-     * @return Entry
-     */
-    public function setObsolete($obsolete)
+    public function setObsolete(?bool $obsolete): self
     {
         $this->obsolete = $obsolete;
 
         return $this;
     }
 
-    /**
-     * @param array $flags
-     *
-     * @return Entry
-     */
-    public function setFlags($flags)
+    public function setFlags(array $flags): self
     {
         $this->flags = $flags;
 
         return $this;
     }
 
-    /**
-     * @param array $translatorComments
-     *
-     * @return Entry
-     */
-    public function setTranslatorComments($translatorComments)
+    public function setTranslatorComments(array $translatorComments): self
     {
         $this->translatorComments = $translatorComments;
 
         return $this;
     }
 
-    /**
-     * @param array $developerComments
-     *
-     * @return Entry
-     */
-    public function setDeveloperComments($developerComments)
+    public function setDeveloperComments(array $developerComments): self
     {
         $this->developerComments = $developerComments;
 
         return $this;
     }
 
-    /**
-     * @param array $reference
-     *
-     * @return Entry
-     */
-    public function setReference($reference)
+    public function setReference(array $reference): self
     {
         $this->reference = $reference;
 
         return $this;
     }
 
-    /**
-     * @param string[] $msgStrPlurals
-     *
-     * @return Entry
-     */
-    public function setMsgStrPlurals($msgStrPlurals)
+    public function setMsgStrPlurals(array $msgStrPlurals): self
     {
         $this->msgStrPlurals = $msgStrPlurals;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getMsgId()
+    public function getMsgId(): string
     {
         return $this->msgId;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getMsgStr()
+    public function getMsgStr(): ?string
     {
         return $this->msgStr;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getMsgIdPlural()
+    public function getMsgIdPlural(): ?string
     {
         return $this->msgIdPlural;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getMsgCtxt()
+    public function getMsgCtxt(): ?string
     {
         return $this->msgCtxt;
     }
 
-    /**
-     * @return null|Entry
-     */
-    public function getPreviousEntry()
+    public function getPreviousEntry(): ?Entry
     {
         return $this->previousEntry;
     }
 
-    /**
-     * @return bool
-     */
-    public function isObsolete()
+    public function isObsolete(): bool
     {
         return $this->obsolete === true;
     }
 
-    /**
-     * @return bool
-     */
-    public function isFuzzy()
+    public function isFuzzy(): bool
     {
         return \in_array('fuzzy', $this->getFlags(), true);
     }
 
-    /**
-     * @return bool
-     */
-    public function isPlural()
+    public function isPlural(): bool
     {
         return $this->getMsgIdPlural() !== null || \count($this->getMsgStrPlurals()) > 0;
     }
 
-    /**
-     * @return array
-     */
-    public function getFlags()
+    public function getFlags(): array
     {
         return $this->flags;
     }
 
-    /**
-     * @return array
-     */
-    public function getTranslatorComments()
+    public function getTranslatorComments(): array
     {
         return $this->translatorComments;
     }
 
-    /**
-     * @return array
-     */
-    public function getDeveloperComments()
+    public function getDeveloperComments(): array
     {
         return $this->developerComments;
     }
 
-    /**
-     * @return array
-     */
-    public function getReference()
+    public function getReference(): array
     {
         return $this->reference;
     }
@@ -283,7 +181,7 @@ class Entry
     /**
      * @return string[]
      */
-    public function getMsgStrPlurals()
+    public function getMsgStrPlurals(): array
     {
         return $this->msgStrPlurals;
     }

--- a/src/Catalog/Entry.php
+++ b/src/Catalog/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\Catalog;
 
 class Entry

--- a/src/Catalog/EntryFactory.php
+++ b/src/Catalog/EntryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\Catalog;
 
 class EntryFactory

--- a/src/Catalog/EntryFactory.php
+++ b/src/Catalog/EntryFactory.php
@@ -4,17 +4,13 @@ namespace Sepia\PoParser\Catalog;
 
 class EntryFactory
 {
-    /**
-     * @param array $entryArray
-     * @return Entry
-     */
-    public static function createFromArray(array $entryArray)
+    public static function createFromArray(array $entryArray): Entry
     {
         $entry = new Entry(
             $entryArray['msgid'],
             isset($entryArray['msgstr']) ? $entryArray['msgstr'] : null
         );
-        $plurals = array();
+        $plurals = [];
 
         foreach ($entryArray as $key => $value) {
             switch (true) {

--- a/src/Catalog/Header.php
+++ b/src/Catalog/Header.php
@@ -54,7 +54,7 @@ class Header
         $header = \array_values(\array_filter(
             $this->headers,
             function ($string) use ($headerName) {
-                return \preg_match('/'.$headerName.':(.*)/i', $string) == 1;
+                return \preg_match('/' . $headerName . ':(.*)/i', $string) === 1;
             }
         ));
 

--- a/src/Catalog/Header.php
+++ b/src/Catalog/Header.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\Catalog;
 
 class Header

--- a/src/Catalog/Header.php
+++ b/src/Catalog/Header.php
@@ -4,18 +4,17 @@ namespace Sepia\PoParser\Catalog;
 
 class Header
 {
-    /** @var array */
-    protected $headers;
+    protected array $headers;
 
-    /** @var int|null */
-    protected $nPlurals;
+    protected ?int $nPlurals;
 
-    public function __construct(array $headers = array())
+    public function __construct(array $headers = [])
     {
         $this->setHeaders($headers);
+        $this->nPlurals = null;
     }
 
-    public function getPluralFormsCount()
+    public function getPluralFormsCount(): int
     {
         if ($this->nPlurals !== null) {
             return $this->nPlurals;
@@ -27,7 +26,7 @@ class Header
             return $this->nPlurals;
         }
 
-        $matches = array();
+        $matches = [];
         if (\preg_match('/nplurals=([0-9]+)/', $header, $matches) !== 1) {
             $this->nPlurals = 0;
             return $this->nPlurals;
@@ -38,25 +37,17 @@ class Header
         return $this->nPlurals;
     }
 
-    public function setHeaders(array $headers)
+    public function setHeaders(array $headers): void
     {
         $this->headers = $headers;
     }
 
-    /**
-     * @return array
-     */
-    public function asArray()
+    public function asArray(): array
     {
         return $this->headers;
     }
 
-    /**
-     * @param string $headerName
-     *
-     * @return string|null
-     */
-    protected function getHeaderValue($headerName)
+    protected function getHeaderValue(string $headerName): ?string
     {
         $header = \array_values(\array_filter(
             $this->headers,

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\Exception;
 
 class ParseException extends \Exception

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -47,24 +47,18 @@ use Sepia\PoParser\SourceHandler\StringSource;
  */
 class Parser
 {
-    /** @var SourceHandler */
-    protected $sourceHandler;
+    protected SourceHandler $sourceHandler;
 
-    /** @var int */
-    protected $lineNumber;
+    protected int $lineNumber;
 
-    /** @var string */
-    protected $property;
+    protected ?string $property;
 
     /**
      * Reads and parses a string
      *
-     * @param string $string po content
-     *
-     * @throws \Exception.
-     * @return Catalog
+     * @throws \Exception
      */
-    public static function parseString($string)
+    public static function parseString(string $string): Catalog
     {
         $parser = new Parser(new StringSource($string));
 
@@ -74,12 +68,9 @@ class Parser
     /**
      * Reads and parses a file
      *
-     * @param string $filePath
-     *
-     * @throws \Exception.
-     * @return Catalog
+     * @throws \Exception
      */
-    public static function parseFile($filePath)
+    public static function parseFile(string $filePath): Catalog
     {
         $parser = new Parser(new FileSystem($filePath));
 
@@ -95,13 +86,12 @@ class Parser
      * Reads and parses strings of a .po file.
      *
      * @throws \Exception, \InvalidArgumentException, ParseException
-     * @return Catalog
      */
-    public function parse(?Catalog $catalog = null)
+    public function parse(?Catalog $catalog = null): Catalog
     {
         $catalog = $catalog === null ? new CatalogArray() : $catalog;
         $this->lineNumber = 0;
-        $entry = array();
+        $entry = [];
         $this->property = null; // current property
 
         // Flags
@@ -125,7 +115,7 @@ class Parser
                     $catalog->addEntry(EntryFactory::createFromArray($entry));
                 }
 
-                $entry = array();
+                $entry = [];
                 $this->property = null;
 
                 if (empty($line)) {
@@ -156,13 +146,9 @@ class Parser
     }
 
     /**
-     * @param string $line
-     * @param array  $entry
-     *
-     * @return array
      * @throws ParseException
      */
-    protected function parseLine($line, $entry)
+    protected function parseLine(string $line, array $entry): array
     {
         $firstChar = \strlen($line) > 0 ? $line[0] : '';
 
@@ -184,13 +170,9 @@ class Parser
     }
 
     /**
-     * @param string $line
-     * @param array  $entry
-     *
-     * @return array
      * @throws ParseException
      */
-    protected function parseProperty($line, array $entry)
+    protected function parseProperty(string $line, array $entry): array
     {
         list($key, $value) = $this->getProperty($line);
 
@@ -220,13 +202,9 @@ class Parser
     }
 
     /**
-     * @param string $line
-     * @param array  $entry
-     *
-     * @return array
      * @throws ParseException
      */
-    protected function parseMultiline($line, $entry)
+    protected function parseMultiline(string $line, array $entry): array
     {
         switch (true) {
             case $this->property === 'msgctxt':
@@ -247,13 +225,9 @@ class Parser
     }
 
     /**
-     * @param string $line
-     * @param array  $entry
-     *
-     * @return array
      * @throws ParseException
      */
-    protected function parseComment($line, $entry)
+    protected function parseComment(string $line, array $entry): array
     {
         $comment = \trim(\substr($line, 0, 2));
 
@@ -264,7 +238,7 @@ class Parser
                 break;
 
             case '#.':
-                $entry['ccomment'] = !isset($entry['ccomment']) ? array() : $entry['ccomment'];
+                $entry['ccomment'] = !isset($entry['ccomment']) ? [] : $entry['ccomment'];
                 $entry['ccomment'][] = \trim(\substr($line, 2));
                 break;
 
@@ -272,17 +246,17 @@ class Parser
             case '#|':  // Previous string
             case '#~':  // Old entry
             case '#~|': // Previous string old
-                $mode = array(
+                $mode = [
                     '#|' => 'previous',
                     '#~' => 'obsolete',
                     '#~|' => 'previous-obsolete'
-                );
+                ];
 
                 $line = \trim(\substr($line, 2));
                 $property = $mode[$comment];
                 if ($property === 'previous') {
                     if (!isset($entry[$property])) {
-                        $subEntry = array();
+                        $subEntry = [];
                     } else {
                         $subEntry = $entry[$property];
                     }
@@ -303,7 +277,7 @@ class Parser
 
             case '#':
             default:
-                $entry['tcomment'] = !isset($entry['tcomment']) ? array() : $entry['tcomment'];
+                $entry['tcomment'] = !isset($entry['tcomment']) ? [] : $entry['tcomment'];
                 $entry['tcomment'][] = \trim(\substr($line, 1));
                 break;
         }
@@ -311,36 +285,19 @@ class Parser
         return $entry;
     }
 
-    /**
-     * @param string $msgstr
-     *
-     * @return Header
-     */
-    protected function parseHeaders($msgstr)
+    protected function parseHeaders(string $msgstr): Header
     {
         $headers = \array_filter(\explode("\n", $msgstr));
 
         return new Header($headers);
     }
 
-    /**
-     * @param string $line
-     * @param array  $entry
-     *
-     * @return bool
-     */
-    protected function shouldIgnoreLine($line, array $entry)
+    protected function shouldIgnoreLine(string $line, array $entry): bool
     {
         return empty($line) && \count($entry) === 0;
     }
 
-    /**
-     * @param string $line
-     * @param array  $entry
-     *
-     * @return bool
-     */
-    protected function shouldCloseEntry($line, array $entry)
+    protected function shouldCloseEntry(string $line, array $entry): bool
     {
         $tokens = $this->getProperty($line);
         $property = $tokens[0];
@@ -348,23 +305,15 @@ class Parser
         return ($line === '' || ($property === 'msgid' && isset($entry['msgid'])));
     }
 
-    /**
-     * @param string $value
-     * @return string
-     */
-    protected function unquote($value)
+    protected function unquote(string $value): string
     {
         return \stripcslashes(\preg_replace('/^\"|\"$/', '', $value));
     }
 
     /**
      * Checks if entry is a header by
-     *
-     * @param array $entry
-     *
-     * @return bool
      */
-    protected function isHeader(array $entry)
+    protected function isHeader(array $entry): bool
     {
         if (empty($entry) || !isset($entry['msgstr'])) {
             return false;
@@ -374,7 +323,7 @@ class Parser
             return false;
         }
 
-        $standardHeaders = array(
+        $standardHeaders = [
             'Project-Id-Version:',
             'Report-Msgid-Bugs-To:',
             'POT-Creation-Date:',
@@ -385,7 +334,7 @@ class Parser
             'Content-Type:',
             'Content-Transfer-Encoding:',
             'Plural-Forms:',
-        );
+        ];
 
         $headers = \explode("\n", $entry['msgstr']);
         // Remove text after double colon
@@ -414,12 +363,7 @@ class Parser
         return \count($customHeaders) > 0;
     }
 
-    /**
-     * @param string $line
-     *
-     * @return array
-     */
-    protected function getProperty($line)
+    protected function getProperty(string $line): array
     {
         $tokens = \preg_split('/\s+/ ', $line, 2);
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser;
 
 use Sepia\PoParser\Catalog\Catalog;
@@ -98,7 +100,7 @@ class Parser
         $headersFound = false;
 
         while (!$this->sourceHandler->ended()) {
-            $line = \trim($this->sourceHandler->getNextLine());
+            $line = \trim((string) $this->sourceHandler->getNextLine());
 
             if ($this->shouldIgnoreLine($line, $entry)) {
                 $this->lineNumber++;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -94,12 +94,10 @@ class Parser
     /**
      * Reads and parses strings of a .po file.
      *
-     * @param SourceHandler . Optional
-     *
      * @throws \Exception, \InvalidArgumentException, ParseException
      * @return Catalog
      */
-    public function parse(Catalog $catalog = null)
+    public function parse(?Catalog $catalog = null)
     {
         $catalog = $catalog === null ? new CatalogArray() : $catalog;
         $this->lineNumber = 0;

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -8,25 +8,18 @@ use Sepia\PoParser\Catalog\Header;
 
 class PoCompiler
 {
-    /** @var string */
-    const TOKEN_OBSOLETE = '#~ ';
+    private const string TOKEN_OBSOLETE = '#~ ';
 
-    /** @var int */
-    protected $wrappingColumn;
+    protected int $wrappingColumn;
 
-    /** @var string */
-    protected $lineEnding;
+    protected string $lineEnding;
 
-    /** @var string */
-    protected $tokenCarriageReturn;
+    protected string $tokenCarriageReturn;
 
     /**
      * PoCompiler constructor.
-     *
-     * @param int    $wrappingColumn
-     * @param string $lineEnding
      */
-    public function __construct($wrappingColumn = 80, $lineEnding = "\n")
+    public function __construct(int $wrappingColumn = 80, string $lineEnding = "\n")
     {
         $this->wrappingColumn = $wrappingColumn;
         $this->lineEnding = $lineEnding;
@@ -36,13 +29,10 @@ class PoCompiler
     /**
      * Compiles entries into a string
      *
-     * @param Catalog $catalog
-     *
-     * @return string
      * @throws \Exception
      * @todo Write obsolete messages at the end of the file.
      */
-    public function compile(Catalog $catalog)
+    public function compile(Catalog $catalog): string
     {
         $output = '';
 
@@ -88,20 +78,12 @@ class PoCompiler
         return $output;
     }
 
-    /**
-     * @return string
-     */
-    protected function eol()
+    protected function eol(): string
     {
         return $this->lineEnding;
     }
 
-    /**
-     * @param $entry
-     *
-     * @return string
-     */
-    protected function buildPreviousEntry(Entry $entry)
+    protected function buildPreviousEntry(Entry $entry): string
     {
         $previous = $entry->getPreviousEntry();
         if ($previous === null) {
@@ -111,12 +93,7 @@ class PoCompiler
         return '#| msgid '.$this->cleanExport($previous->getMsgId()).$this->eol();
     }
 
-    /**
-     * @param $entry
-     *
-     * @return string
-     */
-    protected function buildTranslatorComment(Entry $entry)
+    protected function buildTranslatorComment(Entry $entry): string
     {
         if ($entry->getTranslatorComments() === null) {
             return '';
@@ -130,7 +107,7 @@ class PoCompiler
         return $output;
     }
 
-    protected function buildDeveloperComment(Entry $entry)
+    protected function buildDeveloperComment(Entry $entry): string
     {
         if ($entry->getDeveloperComments() === null) {
             return '';
@@ -144,7 +121,7 @@ class PoCompiler
         return $output;
     }
 
-    protected function buildReference(Entry $entry)
+    protected function buildReference(Entry $entry): string
     {
         $reference = $entry->getReference();
         if ($reference === null || \count($reference) === 0) {
@@ -159,7 +136,7 @@ class PoCompiler
         return $output;
     }
 
-    protected function buildFlags(Entry $entry)
+    protected function buildFlags(Entry $entry): string
     {
         $flags = $entry->getFlags();
         if ($flags === null || \count($flags) === 0) {
@@ -169,7 +146,7 @@ class PoCompiler
         return '#, '.\implode(', ', $flags).$this->eol();
     }
 
-    protected function buildContext(Entry $entry)
+    protected function buildContext(Entry $entry): string
     {
         if ($entry->getMsgCtxt() === null) {
             return '';
@@ -180,7 +157,7 @@ class PoCompiler
             'msgctxt '.$this->cleanExport($entry->getMsgCtxt()).$this->eol();
     }
 
-    protected function buildMsgId(Entry $entry)
+    protected function buildMsgId(Entry $entry): string
     {
         if ($entry->getMsgId() === null) {
             return '';
@@ -189,7 +166,7 @@ class PoCompiler
         return $this->buildProperty('msgid', $entry->getMsgId(), $entry->isObsolete());
     }
 
-    protected function buildMsgStr(Entry $entry, Header $headers)
+    protected function buildMsgStr(Entry $entry, Header $headers): string
     {
         $value = $entry->getMsgStr();
         $plurals = $entry->getMsgStrPlurals();
@@ -214,12 +191,7 @@ class PoCompiler
         return $this->buildProperty('msgstr', $value, $entry->isObsolete());
     }
 
-    /**
-     * @param Entry $entry
-     *
-     * @return string
-     */
-    protected function buildMsgIdPlural(Entry $entry)
+    protected function buildMsgIdPlural(Entry $entry): string
     {
         $value = $entry->getMsgIdPlural();
         if ($value === null) {
@@ -229,7 +201,7 @@ class PoCompiler
         return $this->buildProperty('msgid_plural', $value, $entry->isObsolete());
     }
 
-    protected function buildProperty($property, $value, $obsolete = false)
+    protected function buildProperty(string $property, string $value, $obsolete = false): string
     {
         $tokens = $this->wrapString($value);
 
@@ -249,12 +221,8 @@ class PoCompiler
 
     /**
      * Prepares a string to be outputed into a file.
-     *
-     * @param string $string The string to be converted.
-     *
-     * @return string
      */
-    protected function cleanExport($string)
+    protected function cleanExport(string $string): string
     {
         /**
          * Replace newline character with $this->tokenCarriageReturn that is later replaced back and thus
@@ -269,18 +237,14 @@ class PoCompiler
         return str_replace($this->tokenCarriageReturn, '\n', $string);
     }
 
-    /**
-     * @param string $value
-     * @return array
-     */
-    private function wrapString($value)
+    private function wrapString(string $value): array
     {
         $length = mb_strlen($value);
         if ($length <= $this->wrappingColumn) {
-            return array($value);
+            return [$value];
         }
 
-        $lines = array();
+        $lines = [];
         $parts = preg_split('/( )/', $value, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         $lineIndex = 0;
         foreach ($parts as $part) {

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -203,7 +203,7 @@ class PoCompiler
         return $this->buildProperty('msgid_plural', $value, $entry->isObsolete());
     }
 
-    protected function buildProperty(string $property, string $value, $obsolete = false): string
+    protected function buildProperty(string $property, string $value, bool $obsolete = false): string
     {
         $tokens = $this->wrapString($value);
 

--- a/src/PoCompiler.php
+++ b/src/PoCompiler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser;
 
 use Sepia\PoParser\Catalog\Catalog;

--- a/src/SourceHandler/FileSystem.php
+++ b/src/SourceHandler/FileSystem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\SourceHandler;
 
 /**

--- a/src/SourceHandler/FileSystem.php
+++ b/src/SourceHandler/FileSystem.php
@@ -34,13 +34,12 @@ namespace Sepia\PoParser\SourceHandler;
  */
 class FileSystem implements SourceHandler
 {
-    /** @var resource */
+    /** @var ?resource */
     protected $fileHandle;
 
-    /** @var string */
-    protected $filePath;
+    protected string $filePath;
 
-    public function __construct($filePath)
+    public function __construct(string $filePath)
     {
         $this->filePath = $filePath;
         $this->fileHandle = null;
@@ -49,7 +48,7 @@ class FileSystem implements SourceHandler
     /**
      * @throws \Exception
      */
-    protected function openFile()
+    protected function openFile(): void
     {
         if ($this->fileHandle !== null) {
             return;
@@ -70,10 +69,9 @@ class FileSystem implements SourceHandler
     }
 
     /**
-     * @return bool|string
      * @throws \Exception
      */
-    public function getNextLine()
+    public function getNextLine(): false|string
     {
         $this->openFile();
 
@@ -81,17 +79,16 @@ class FileSystem implements SourceHandler
     }
 
     /**
-     * @return bool
      * @throws \Exception
      */
-    public function ended()
+    public function ended(): bool
     {
         $this->openFile();
 
         return \feof($this->fileHandle);
     }
 
-    public function close()
+    public function close(): bool
     {
         if ($this->fileHandle === null) {
             return true;
@@ -101,15 +98,11 @@ class FileSystem implements SourceHandler
     }
 
     /**
-     * @param $output
-     * @param $filePath
-     *
-     * @return bool
      * @throws \Exception
      */
-    public function save($output)
+    public function save(string $poString): true
     {
-        $result = \file_put_contents($this->filePath, $output);
+        $result = \file_put_contents($this->filePath, $poString);
         if ($result === false) {
             throw new \Exception('Could not write into file '.\htmlspecialchars($this->filePath));
         }

--- a/src/SourceHandler/SourceHandler.php
+++ b/src/SourceHandler/SourceHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\SourceHandler;
 
 /**

--- a/src/SourceHandler/SourceHandler.php
+++ b/src/SourceHandler/SourceHandler.php
@@ -34,8 +34,8 @@ namespace Sepia\PoParser\SourceHandler;
  */
 interface SourceHandler
 {
-    public function getNextLine();
-    public function ended();
-    public function close();
-    public function save($poString);
+    public function getNextLine(): false|string;
+    public function ended(): bool;
+    public function close(): bool;
+    public function save(string $poString): true;
 }

--- a/src/SourceHandler/StringSource.php
+++ b/src/SourceHandler/StringSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\PoParser\SourceHandler;
 
 /**

--- a/src/SourceHandler/StringSource.php
+++ b/src/SourceHandler/StringSource.php
@@ -35,22 +35,20 @@ namespace Sepia\PoParser\SourceHandler;
 class StringSource implements SourceHandler
 {
     /** @var string[] */
-    protected $strings;
+    protected array $strings;
 
-    /** @var int */
-    protected $line;
+    protected int $line;
 
-    /** @var int */
-    protected $total;
+    protected int $total;
 
-    public function __construct($string)
+    public function __construct(string $string)
     {
         $this->line = 0;
         $this->strings = \explode("\n",$string);
         $this->total = \count($this->strings);
     }
 
-    public function getNextLine()
+    public function getNextLine(): false|string
     {
         if (isset($this->strings[$this->line])) {
             $result = $this->strings[$this->line];
@@ -61,17 +59,19 @@ class StringSource implements SourceHandler
         return $result;
     }
 
-    public function ended()
+    public function ended(): bool
     {
         return ($this->line>=$this->total);
     }
 
-    public function close()
+    public function close(): bool
     {
         $this->line = 0;
+        return true;
     }
 
-    public function save($ignore)
+    public function save(string $poString): true
     {
+        return true;
     }
 }

--- a/tests/AbstractFixtureTestCase.php
+++ b/tests/AbstractFixtureTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\Test;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/AbstractFixtureTestCase.php
+++ b/tests/AbstractFixtureTestCase.php
@@ -6,22 +6,16 @@ use PHPUnit\Framework\TestCase;
 use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Parser;
 
-abstract class AbstractFixtureTest extends TestCase
+abstract class AbstractFixtureTestCase extends TestCase
 {
-    /** @var string */
-    protected $resourcesPath;
+    protected string $resourcesPath;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->resourcesPath = \dirname(__DIR__).'/fixtures/';
     }
 
-    /**
-     * @param string $file
-     *
-     * @return Catalog
-     */
-    protected function parseFile($file)
+    protected function parseFile(string $file): Catalog
     {
         //try {
             return Parser::parseFile($this->resourcesPath.$file);

--- a/tests/EntryBuilder.php
+++ b/tests/EntryBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\Test;
 
 use Sepia\PoParser\Catalog\Entry;

--- a/tests/EntryBuilder.php
+++ b/tests/EntryBuilder.php
@@ -35,17 +35,17 @@ class EntryBuilder
         return $entry;
     }
 
-    private $msgId;
-    private $msgPluralId;
-    private $msgStr;
-    private $context;
-    private $reference;
-    private $translatorComments;
-    private $developerComments;
-    private $flags;
-    private $previousEntry;
-    private $obsolete;
-    private $pluralTranslations;
+    private string $msgId;
+    private ?string $msgPluralId;
+    private ?string $msgStr;
+    private ?string $context;
+    private array $reference;
+    private array $translatorComments;
+    private array $developerComments;
+    private array $flags;
+    private ?Entry $previousEntry;
+    private bool $obsolete;
+    private array $pluralTranslations;
 
     public function __construct()
     {

--- a/tests/EntryBuilder.php
+++ b/tests/EntryBuilder.php
@@ -114,7 +114,7 @@ class EntryBuilder
         return $this;
     }
 
-    public function withFlags(array $flags)
+    public function withFlags(array $flags): self
     {
         $this->flags = $flags;
         return $this;

--- a/tests/UnitTest/HeaderTest.php
+++ b/tests/UnitTest/HeaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\Test\UnitTest;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/UnitTest/HeaderTest.php
+++ b/tests/UnitTest/HeaderTest.php
@@ -3,21 +3,19 @@
 namespace Sepia\Test\UnitTest;
 
 use PHPUnit\Framework\TestCase;
+use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Parser;
 
 class HeaderTest extends TestCase
 {
-    public function testGetPluralFormsCount()
+    public function testGetPluralFormsCount(): void
     {
         $catalog = $this->parseFile();
 
         $this->assertEquals(3, $catalog->getHeader()->getPluralFormsCount());
     }
 
-    /**
-     * @return \Sepia\PoParser\Catalog\Catalog
-     */
-    protected function parseFile()
+    protected function parseFile(): Catalog
     {
         return Parser::parseFile(\dirname(\dirname(__DIR__)).'/fixtures/basicHeadersMultiline.po');
     }

--- a/tests/UnitTest/ParserTest.php
+++ b/tests/UnitTest/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\Test\UnitTest;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/UnitTest/ParserTest.php
+++ b/tests/UnitTest/ParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sepia\Test\UnitTest;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Catalog\Header;
@@ -12,7 +13,7 @@ use Sepia\PoParser\SourceHandler\StringSource;
 
 class ParserTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function should_parse_headers(): void
     {
         $doc =

--- a/tests/UnitTest/ParserTest.php
+++ b/tests/UnitTest/ParserTest.php
@@ -3,6 +3,7 @@
 namespace Sepia\Test\UnitTest;
 
 use PHPUnit\Framework\TestCase;
+use Sepia\PoParser\Catalog\Catalog;
 use Sepia\PoParser\Catalog\Header;
 use Sepia\PoParser\Parser;
 use Sepia\PoParser\SourceHandler\StringSource;
@@ -10,7 +11,7 @@ use Sepia\PoParser\SourceHandler\StringSource;
 class ParserTest extends TestCase
 {
     /** @test */
-    public function should_parse_headers()
+    public function should_parse_headers(): void
     {
         $doc =
         'msgid ""
@@ -23,10 +24,10 @@ class ParserTest extends TestCase
         ';
         $catalog = $this->parse($doc);
 
-        $expectedHeaders = new Header(array(
+        $expectedHeaders = new Header([
             'Project-Id-Version: value 1',
             'Report-Msgid-Bugs-To: value 2',
-        ));
+        ]);
         $this->assertEquals(
             $expectedHeaders,
             $catalog->getHeader()
@@ -34,11 +35,9 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @param string $doc
-     * @return \Sepia\PoParser\Catalog\Catalog|\Sepia\PoParser\Catalog\CatalogArray
      * @throws \Exception
      */
-    public function parse(string $doc)
+    public function parse(string $doc): Catalog
     {
         $parser = new Parser(new StringSource($doc));
         return $parser->parse();

--- a/tests/UnitTest/PoCompilerTest.php
+++ b/tests/UnitTest/PoCompilerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\Test\UnitTest;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/UnitTest/PoCompilerTest.php
+++ b/tests/UnitTest/PoCompilerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sepia\Test\UnitTest;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Sepia\PoParser\Catalog\CatalogArray;
 use Sepia\PoParser\PoCompiler;
@@ -11,7 +13,7 @@ use Sepia\Test\EntryBuilder;
 
 class PoCompilerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function should_compile_single_line_translation(): void
     {
         $catalog = new CatalogArray([
@@ -58,7 +60,7 @@ class PoCompilerTest extends TestCase
             , $output);
     }
 
-    /** @test */
+    #[Test]
     public function should_compile_obsolete_translation(): void
     {
         $catalog = new CatalogArray([
@@ -81,7 +83,7 @@ class PoCompilerTest extends TestCase
             , $output);
     }
 
-    /** @test */
+    #[Test]
     public function should_compile_multiple_line_translation(): void
     {
         $catalog = new CatalogArray([
@@ -103,7 +105,7 @@ class PoCompilerTest extends TestCase
             , $output);
     }
 
-    /** @test */
+    #[Test]
     public function should_compile_translation_with_plurals(): void
     {
         $catalog = new CatalogArray([
@@ -132,7 +134,7 @@ class PoCompilerTest extends TestCase
             , $output);
     }
 
-    /** @test */
+    #[Test]
     public function should_compile_obsolete_plurals(): void
     {
         $catalog = new CatalogArray([
@@ -162,7 +164,7 @@ class PoCompilerTest extends TestCase
             , $output);
     }
 
-    /** @test */
+    #[Test]
     public function should_compile_escaping_special_chars(): void
     {
         $catalog = new CatalogArray([
@@ -197,10 +199,8 @@ msgstr "proper\nlinebreaks"
 ', $output);
     }
 
-    /**
-     * @test
-     * @dataProvider wrappingDataProvider
-     */
+    #[Test]
+    #[DataProvider('wrappingDataProvider')]
     public function should_compile_translation_with_wrapping_long_lines(string $value, int $wrappingColumn, bool $shouldWrapLines, array $assert): void
     {
         // Make sure that encoding is set to UTF-8 for this test

--- a/tests/UnitTest/PoCompilerTest.php
+++ b/tests/UnitTest/PoCompilerTest.php
@@ -10,7 +10,7 @@ use Sepia\Test\EntryBuilder;
 class PoCompilerTest extends TestCase
 {
     /** @test */
-    public function should_compile_single_line_translation()
+    public function should_compile_single_line_translation(): void
     {
         $catalog = new CatalogArray([
             EntryBuilder::anEntry()
@@ -57,7 +57,7 @@ class PoCompilerTest extends TestCase
     }
 
     /** @test */
-    public function should_compile_obsolete_translation()
+    public function should_compile_obsolete_translation(): void
     {
         $catalog = new CatalogArray([
             EntryBuilder::anEntry()
@@ -80,7 +80,7 @@ class PoCompilerTest extends TestCase
     }
 
     /** @test */
-    public function should_compile_multiple_line_translation()
+    public function should_compile_multiple_line_translation(): void
     {
         $catalog = new CatalogArray([
             EntryBuilder::anEntry()
@@ -102,7 +102,7 @@ class PoCompilerTest extends TestCase
     }
 
     /** @test */
-    public function should_compile_translation_with_plurals()
+    public function should_compile_translation_with_plurals(): void
     {
         $catalog = new CatalogArray([
             EntryBuilder::anEntry()
@@ -131,7 +131,7 @@ class PoCompilerTest extends TestCase
     }
 
     /** @test */
-    public function should_compile_obsolete_plurals()
+    public function should_compile_obsolete_plurals(): void
     {
         $catalog = new CatalogArray([
             EntryBuilder::anEntry()
@@ -161,7 +161,7 @@ class PoCompilerTest extends TestCase
     }
 
     /** @test */
-    public function should_compile_escaping_special_chars()
+    public function should_compile_escaping_special_chars(): void
     {
         $catalog = new CatalogArray([
             EntryBuilder::anEntry()
@@ -199,7 +199,7 @@ msgstr "proper\nlinebreaks"
      * @test
      * @dataProvider wrappingDataProvider
      */
-    public function should_compile_translation_with_wrapping_long_lines(string $value, int $wrappingColumn, bool $shouldWrapLines, array $assert)
+    public function should_compile_translation_with_wrapping_long_lines(string $value, int $wrappingColumn, bool $shouldWrapLines, array $assert): void
     {
         // Make sure that encoding is set to UTF-8 for this test
         \mb_internal_encoding();
@@ -228,54 +228,54 @@ msgstr "proper\nlinebreaks"
         $this->assertEquals($expected, $output);
     }
 
-    public function wrappingDataProvider(): array
+    public static function wrappingDataProvider(): array
     {
-        return array(
-            'Multibyte Wrap (char 81)' => array(
+        return [
+            'Multibyte Wrap (char 81)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen.... this is a multibyte translation á with a multibyte beginning at char 81.',
                 'wrappingColumn' => 80,
-                'shouldWrap' => true,
-                'assert' => array(
+                'shouldWrapLines' => true,
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen.... this is a multibyte translation ',
                     'á with a multibyte beginning at char 81.'
-                ),
-            ),
-            'Multibyte Wrap (char 80)' => array(
+                ],
+            ],
+            'Multibyte Wrap (char 80)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen... this is a multibyte translation á with a multibyte beginning at char 80.',
                 'wrappingColumn' => 80,
-                'shouldWrap' => true,
-                'assert' => array(
+                'shouldWrapLines' => true,
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen... this is a multibyte translation á',
                     ' with a multibyte beginning at char 80.'
-                ),
-            ),
-            'Multibyte Wrap (char 79)' => array(
+                ],
+            ],
+            'Multibyte Wrap (char 79)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen.. this is a multibyte translation á with multibytes beginning at char 79.',
                 'wrappingColumn' => 80,
-                'shouldWrap' => true,
-                'assert' => array(
+                'shouldWrapLines' => true,
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen.. this is a multibyte translation á ',
                     'with multibytes beginning at char 79.'
-                ),
-            ),
-            'Escape-Sequence Wrap (char 80+81)' => array(
+                ],
+            ],
+            'Escape-Sequence Wrap (char 80+81)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen..... this is a line with more than \"eighty\" chars. And char 80+81 is an escaped double quote.',
                 'wrappingColumn' => 80,
-                'shouldWrap' => true,
-                'assert' => array(
+                'shouldWrapLines' => true,
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen..... this is a line with more than ',
                     '\\\\\"eighty\\\\\" chars. And char 80+81 is an escaped double quote.'
-                ),
-            ),
-            'Escape-Sequence Wrap (char 79+80)' => array(
+                ],
+            ],
+            'Escape-Sequence Wrap (char 79+80)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen.... this is a line with more than \"eighty\" chars. And char 79+80 is an escaped double quote.',
                 'wrappingColumn' => 80,
-                'shouldWrap' => true,
-                'assert' => array(
+                'shouldWrapLines' => true,
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen.... this is a line with more than ',
                     '\\\\\"eighty\\\\\" chars. And char 79+80 is an escaped double quote.'
-                ),
-            ),
+                ],
+            ],
             /*    'Escaped Line-break' => array(
                     'value' => 'Hello everybody, \\nHello ladies and gentlemen.',
                     'wrappingColumn' => 80,
@@ -283,14 +283,14 @@ msgstr "proper\nlinebreaks"
                         'Hello everybody, \\\\nHello ladies and gentlemen.'
                     ),
                 ),
-              */  'String with a lot of multibyte characters should not break when wrappingColumn is at its mb_strlen' => array(
+              */ 'String with a lot of multibyte characters should not break when wrappingColumn is at its mb_strlen' => [
                 'value' => 'kategóriáját kötelező',
                 'wrappingColumn' => 21,
-                'shouldWrap' => false,
-                'assert' => array(
+                'shouldWrapLines' => false,
+                'assert' => [
                     'kategóriáját kötelező'
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 }

--- a/tests/UnitTest/ReadPoTest.php
+++ b/tests/UnitTest/ReadPoTest.php
@@ -3,11 +3,11 @@
 namespace Sepia\Test\UnitTest;
 
 use Sepia\PoParser\Catalog\Entry;
-use Sepia\Test\AbstractFixtureTest;
+use Sepia\Test\AbstractFixtureTestCase;
 
-class ReadPoTest extends AbstractFixtureTest
+class ReadPoTest extends AbstractFixtureTestCase
 {
-    public function testBasic()
+    public function testBasic(): void
     {
         $catalog = $this->parseFile('basic.po');
 
@@ -23,7 +23,7 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertEquals('translation "quoted"', $entry->getMsgStr());
     }
 
-    public function testBasicMultiline()
+    public function testBasicMultiline(): void
     {
         $catalog = $this->parseFile('basicMultiline.po');
 
@@ -34,7 +34,7 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertEquals('translation line 1 translation line 2', $entry->getMsgStr());
     }
 
-    public function testBasicCollection()
+    public function testBasicCollection(): void
     {
         $catalog = $this->parseFile('basicCollection.po');
 
@@ -51,7 +51,7 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertEquals('translation.2', $entry->getMsgStr());
     }
 
-    public function testEntriesWithContext()
+    public function testEntriesWithContext(): void
     {
         $catalog = $this->parseFile('context.po');
 
@@ -65,7 +65,7 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertNotEquals($withContext, $withoutContext);
     }
 
-    public function testPlurals()
+    public function testPlurals(): void
     {
         $catalog = $this->parseFile('plurals.po');
 
@@ -73,15 +73,15 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertNotNull($entry);
         $this->assertNotEmpty($entry->getMsgStrPlurals());
         $this->assertEquals(
-            array(
+            [
                 '%s entrada no actualizada, alguien la está editando.',
                 '%s entradas no actualizadas, alguien las está editando.',
-            ),
+            ],
             $entry->getMsgStrPlurals()
         );
     }
 
-    public function testPluralsMultiline()
+    public function testPluralsMultiline(): void
     {
         $catalog = $this->parseFile('pluralsMultiline.po');
         $entry = $catalog->getEntry('%s post not updated,somebody is editing it.');
@@ -89,15 +89,15 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertNotNull($entry);
         $this->assertNotEmpty($entry->getMsgStrPlurals());
         $this->assertEquals(
-            array(
+            [
                 '%s entrada no actualizada,alguien la está editando.',
                 '%s entradas no actualizadas,alguien las está editando.',
-            ),
+            ],
             $entry->getMsgStrPlurals()
         );
     }
 
-    public function testEmptyPlurals()
+    public function testEmptyPlurals(): void
     {
         $catalog = $this->parseFile('plurals.po');
 
@@ -107,7 +107,7 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertEmpty($entry->getMsgStrPlurals());
     }
 
-    public function testFlags()
+    public function testFlags(): void
     {
         $catalog = $this->parseFile('multiflags.po');
 
@@ -116,40 +116,40 @@ class ReadPoTest extends AbstractFixtureTest
 
         $this->assertNotNull($entry);
         $this->assertCount(2, $entry->getFlags());
-        $this->assertEquals(array('php-format', 'fuzzy'), $entry->getFlags());
+        $this->assertEquals(['php-format', 'fuzzy'], $entry->getFlags());
     }
 
-    public function testTranslatorComment()
+    public function testTranslatorComment(): void
     {
         $catalog = $this->parseFile('translatorComments.po');
         $entry = $catalog->getEntry('string.1');
 
         $this->assertNotNull($entry);
         $this->assertEquals(
-            array('translator comment', 'second translator comment'),
+            ['translator comment', 'second translator comment'],
             $entry->getTranslatorComments()
         );
     }
 
-    public function testDeveloperComment()
+    public function testDeveloperComment(): void
     {
         $catalog = $this->parseFile('codeComments.po');
         $entry = $catalog->getEntry('string.1');
 
         $this->assertNotNull($entry);
-        $this->assertEquals(array('code comment', 'code translator comment'), $entry->getDeveloperComments());
+        $this->assertEquals(['code comment', 'code translator comment'], $entry->getDeveloperComments());
     }
 
-    public function testReferences()
+    public function testReferences(): void
     {
         $catalog = $this->parseFile('basicReference.po');
 
         $entry = $catalog->getEntry('string.1');
         $this->assertNotNull($entry);
-        $this->assertEquals(array('src/views/forms.php:44'), $entry->getReference());
+        $this->assertEquals(['src/views/forms.php:44'], $entry->getReference());
     }
 
-    public function testPreviousString()
+    public function testPreviousString(): void
     {
         $catalog = $this->parseFile('previousString.po');
 
@@ -163,7 +163,7 @@ class ReadPoTest extends AbstractFixtureTest
         );
     }
 
-    public function testPreviousStringMultiline()
+    public function testPreviousStringMultiline(): void
     {
         $catalog = $this->parseFile('previousStringMultiline.po');
 
@@ -176,41 +176,41 @@ class ReadPoTest extends AbstractFixtureTest
         $this->assertEquals('Doloribus nulla odit et aut est. Rerum molestiae pariatur suscipit unde in quidem alias alias. Ut ea omnis placeat rerum quae asperiores. Et recusandae praesentium ea.', $previous->getMsgStr());
     }
 
-    public function testHeaders()
+    public function testHeaders(): void
     {
         $catalog = $this->parseFile('basicHeader.po');
         $this->assertCount(1, $catalog->getEntries());
     }
 
-    public function testOnlyCustomHeaders()
+    public function testOnlyCustomHeaders(): void
     {
         $catalog = $this->parseFile('basicCustomHeaders.po');
         $this->assertCount(1, $catalog->getEntries());
         $this->assertGreaterThanOrEqual(1, \count($catalog->getHeaders()));
     }
 
-    public function testHeadersMultiline()
+    public function testHeadersMultiline(): void
     {
         $catalog = $this->parseFile('basicHeadersMultiline.po');
         $this->assertCount(1, $catalog->getEntries());
         $this->assertCount(3,$catalog->getHeaders());
     }
 
-    public function testFileWithOnlyHeaders()
+    public function testFileWithOnlyHeaders(): void
     {
         $catalog = $this->parseFile('basicOnlyHeader.po');
         $this->assertCount(0, $catalog->getEntries());
         $this->assertGreaterThanOrEqual(1, \count($catalog->getHeaders()));
     }
 
-    public function testNoBlankLinesSeparatingEntries()
+    public function testNoBlankLinesSeparatingEntries(): void
     {
         $catalog = $this->parseFile('noblankline.po');
 
         $this->assertCount(2, $catalog->getEntries());
     }
 
-    public function testProperQuotesEscaping()
+    public function testProperQuotesEscaping(): void
     {
         $catalog = $this->parseFile('quotes.po');
 

--- a/tests/UnitTest/ReadPoTest.php
+++ b/tests/UnitTest/ReadPoTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\Test\UnitTest;
 
 use Sepia\PoParser\Catalog\Entry;

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -6,6 +6,7 @@ namespace Sepia\Test;
 
 use Exception;
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use ReflectionException;
 use Sepia\PoParser\Catalog\Catalog;
@@ -180,9 +181,7 @@ class WriteTest extends AbstractFixtureTestCase
         ];
     }
 
-    /**
-     * @dataProvider wrappingDataProvider
-     */
+    #[DataProvider('wrappingDataProvider')]
     public function testWrapping(string $value, int $wrappingColumn, array $assert): void
     {
 

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sepia\Test;
 
 use Exception;

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -12,37 +12,42 @@ use Sepia\PoParser\Catalog\EntryFactory;
 use Sepia\PoParser\PoCompiler;
 use Sepia\PoParser\SourceHandler\FileSystem;
 
-class WriteTest extends AbstractFixtureTest
+class WriteTest extends AbstractFixtureTestCase
 {
-    public function testWrite()
+    protected function setUp(): void
+    {
+        $this->markTestSkipped("Faker is abandoned");
+    }
+
+    public function testWrite(): void
     {
         $faker = Factory::create();
         $catalogSource = new CatalogArray();
 
         // Normal Entry
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => 'string.1',
             'msgstr' => 'translation.1',
             'msgctxt' => 'context.1',
-            'reference' => array('src/views/forms.php:44'),
-            'tcomment' => array('translator comment'),
-            'ccomment' => array('code comment'),
-            'flags' => array('1', '2', '3')
-        ));
-        $previousEntry = EntryFactory::createFromArray(array(
+            'reference' => ['src/views/forms.php:44'],
+            'tcomment' => ['translator comment'],
+            'ccomment' => ['code comment'],
+            'flags' => ['1', '2', '3'],
+        ]);
+        $previousEntry = EntryFactory::createFromArray([
            'msgid' => 'previous.string.1',
-           'msgctxt' => 'previous.context.1'
-        ));
+           'msgctxt' => 'previous.context.1',
+        ]);
         $entry->setPreviousEntry($previousEntry);
         $catalogSource->addEntry($entry);
 
         // Obsolete entry
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => 'obsolete.1',
             'msgstr' => $faker->paragraph(5),
             'msgctxt' => 'obsolete.context',
-            'obsolete' => true
-        ));
+            'obsolete' => true,
+        ]);
         $catalogSource->addEntry($entry);
 
         try {
@@ -55,21 +60,21 @@ class WriteTest extends AbstractFixtureTest
         $this->assertPoFile($catalogSource, $catalog);
     }
 
-    public function testWritePlurals()
+    public function testWritePlurals(): void
     {
         $catalogSource = new CatalogArray();
         // Normal Entry
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => 'string.1',
             'msgstr' => 'translation.1',
             'msgstr[0]' => 'translation.plural.0',
             'msgstr[1]' => 'translation.plural.1',
             'msgstr[2]' => 'translation.plural.2',
-            'reference' => array('src/views/forms.php:44'),
-            'tcomment' => array('translator comment'),
-            'ccomment' => array('code comment'),
-            'flags' => array('1', '2', '3')
-        ));
+            'reference' => ['src/views/forms.php:44'],
+            'tcomment' => ['translator comment'],
+            'ccomment' => ['code comment'],
+            'flags' => ['1', '2', '3'],
+        ]);
 
         $catalogSource->addEntry($entry);
 
@@ -83,27 +88,27 @@ class WriteTest extends AbstractFixtureTest
         $this->assertCount(3, $entry->getMsgStrPlurals());
     }
 
-    public function testDoubleEscaped()
+    public function testDoubleEscaped(): void
     {
         $catalogSource = new CatalogArray();
         // Normal Entry
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => 'a\"b\"c',
-            'msgstr' => 'quotes'
-        ));
+            'msgstr' => 'quotes',
+        ]);
         $catalogSource->addEntry($entry);
 
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => 'a\nb\nc',
-            'msgstr' => 'slashes'
-        ));
+            'msgstr' => 'slashes',
+        ]);
         $catalogSource->addEntry($entry);
 
         // Entry with line breaks
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => "a\nb\nc",
-            'msgstr' => "proper\nlinebreaks"
-        ));
+            'msgstr' => "proper\nlinebreaks",
+        ]);
         $catalogSource->addEntry($entry);
 
         try {
@@ -119,74 +124,70 @@ class WriteTest extends AbstractFixtureTest
         $this->assertNotNull($catalog->getEntry("a\nb\nc"));
     }
 
-    public function wrappingDataProvider()
+    public static function wrappingDataProvider(): array
     {
-        return array(
-            'Multibyte Wrap (char 81)' => array(
+        return [
+            'Multibyte Wrap (char 81)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen.... this is a multibyte translation á with a multibyte beginning at char 81.',
                 'wrappingColumn' => 80,
-                'assert' => array(
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen.... this is a multibyte translation ',
-                    'á with a multibyte beginning at char 81.'
-                ),
-            ),
-            'Multibyte Wrap (char 80)' => array(
+                    'á with a multibyte beginning at char 81.',
+                ],
+            ],
+            'Multibyte Wrap (char 80)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen... this is a multibyte translation á with a multibyte beginning at char 80.',
                 'wrappingColumn' => 80,
-                'assert' => array(
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen... this is a multibyte translation á',
-                    ' with a multibyte beginning at char 80.'
-                ),
-            ),
-            'Multibyte Wrap (char 79)' => array(
+                    ' with a multibyte beginning at char 80.',
+                ],
+            ],
+            'Multibyte Wrap (char 79)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen.. this is a multibyte translation á with multibytes beginning at char 79.',
                 'wrappingColumn' => 80,
-                'assert' => array(
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen.. this is a multibyte translation á ',
-                    'with multibytes beginning at char 79.'
-                ),
-            ),
-            'Escape-Sequence Wrap (char 80+81)' => array(
+                    'with multibytes beginning at char 79.',
+                ],
+            ],
+            'Escape-Sequence Wrap (char 80+81)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen..... this is a line with more than \"eighty\" chars. And char 80+81 is an escaped double quote.',
                 'wrappingColumn' => 80,
-                'assert' => array(
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen..... this is a line with more than ',
-                    '\"eighty\" chars. And char 80+81 is an escaped double quote.'
-                ),
-            ),
-            'Escape-Sequence Wrap (char 79+80)' => array(
+                    '\"eighty\" chars. And char 80+81 is an escaped double quote.',
+                ],
+            ],
+            'Escape-Sequence Wrap (char 79+80)' => [
                 'value' => 'Hello everybody, Hello ladies and gentlemen.... this is a line with more than \"eighty\" chars. And char 79+80 is an escaped double quote.',
                 'wrappingColumn' => 80,
-                'assert' => array(
+                'assert' => [
                     'Hello everybody, Hello ladies and gentlemen.... this is a line with more than ',
-                    '\"eighty\" chars. And char 79+80 is an escaped double quote.'
-                ),
-            ),
-            'Escaped Line-break' => array(
+                    '\"eighty\" chars. And char 79+80 is an escaped double quote.',
+                ],
+            ],
+            'Escaped Line-break' => [
                 'value' => 'Hello everybody, \\nHello ladies and gentlemen.',
                 'wrappingColumn' => 80,
-                'assert' => array(
-                    'Hello everybody, \\nHello ladies and gentlemen.'
-                ),
-            ),
-            'String with a lot of multibyte characters should not break when wrappingColumn is at its mb_strlen' => array(
+                'assert' => [
+                    'Hello everybody, \\nHello ladies and gentlemen.',
+                ],
+            ],
+            'String with a lot of multibyte characters should not break when wrappingColumn is at its mb_strlen' => [
                 'value' => 'kategóriáját kötelező',
                 'wrappingColumn' => 21,
-                'assert' => array(
-                    'kategóriáját kötelező'
-                ),
-            ),
-        );
+                'assert' => [
+                    'kategóriáját kötelező',
+                ],
+            ],
+        ];
     }
 
     /**
      * @dataProvider wrappingDataProvider
-     *
-     * @param string $value
-     * @param int $wrappingColumn
-     * @param array $assert
      */
-    public function testWrapping($value, $wrappingColumn, array $assert)
+    public function testWrapping(string $value, int $wrappingColumn, array $assert): void
     {
 
         // Make sure that encoding is set to UTF-8 for this test
@@ -206,7 +207,7 @@ class WriteTest extends AbstractFixtureTest
         }
 
         // Test the private method
-        $res = $method->invokeArgs($compiler, array($value));
+        $res = $method->invokeArgs($compiler, [$value]);
         $this->assertEquals($assert, $res);
 
 
@@ -218,10 +219,10 @@ class WriteTest extends AbstractFixtureTest
 
         $translation = $faker->paragraph(5);
 
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => $value,
-            'msgstr' => $translation
-        ));
+            'msgstr' => $translation,
+        ]);
 
         $catalogSource->addEntry($entry);
         try {
@@ -242,25 +243,25 @@ class WriteTest extends AbstractFixtureTest
     }
 
 
-    public function testWriteObsoletePlural()
+    public function testWriteObsoletePlural(): void
     {
 
         $catalogSource = new CatalogArray();
 
         // Obsolete entry
-        $entry = EntryFactory::createFromArray(array(
+        $entry = EntryFactory::createFromArray([
             'msgid' => '%d obsolete string',
             'msgid_plural' => '%d obsolete strings',
             'msgstr' => 'translation.2',
             'msgstr[0]' => 'translation.plural.0',
             'msgstr[1]' => 'translation.plural.1',
             'msgstr[2]' => 'translation.plural.2',
-            'reference' => array('src/views/forms.php:45'),
-            'tcomment' => array('translator comment'),
-            'ccomment' => array('code comment'),
-            'flags' => array('fuzzy'),
-            'obsolete' => true
-        ));
+            'reference' => ['src/views/forms.php:45'],
+            'tcomment' => ['translator comment'],
+            'ccomment' => ['code comment'],
+            'flags' => ['fuzzy'],
+            'obsolete' => true,
+        ]);
 
         $catalogSource->addEntry($entry);
 
@@ -287,18 +288,16 @@ class WriteTest extends AbstractFixtureTest
     }
 
     /**
-     * @param Catalog $catalog
-     * @param int $wrappingColumn
      * @throws Exception
      */
-    protected function saveCatalog(Catalog $catalog, $wrappingColumn = 80)
+    protected function saveCatalog(Catalog $catalog, int $wrappingColumn = 80): void
     {
         $fileHandler = new FileSystem($this->resourcesPath.'temp.po');
         $compiler = new PoCompiler($wrappingColumn);
         $fileHandler->save($compiler->compile($catalog));
     }
 
-    private function assertPoFile(CatalogArray $catalogSource, Catalog $catalogNew)
+    private function assertPoFile(CatalogArray $catalogSource, Catalog $catalogNew): void
     {
         foreach ($catalogSource->getEntries() as $entry) {
             $entryWritten = $catalogNew->getEntry($entry->getMsgId(), $entry->getMsgCtxt());
@@ -322,7 +321,7 @@ class WriteTest extends AbstractFixtureTest
         }
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -16,14 +16,8 @@ use Sepia\PoParser\SourceHandler\FileSystem;
 
 class WriteTest extends AbstractFixtureTestCase
 {
-    protected function setUp(): void
-    {
-        $this->markTestSkipped("Faker is abandoned");
-    }
-
     public function testWrite(): void
     {
-        $faker = Factory::create();
         $catalogSource = new CatalogArray();
 
         // Normal Entry
@@ -46,7 +40,7 @@ class WriteTest extends AbstractFixtureTestCase
         // Obsolete entry
         $entry = EntryFactory::createFromArray([
             'msgid' => 'obsolete.1',
-            'msgstr' => $faker->paragraph(5),
+            'msgstr' => 'Test string',
             'msgctxt' => 'obsolete.context',
             'obsolete' => true,
         ]);
@@ -216,10 +210,9 @@ class WriteTest extends AbstractFixtureTestCase
         // Create a po-file with all the test-values as msgid and a fake translation as msgstr
         // And test if the entry could be fetched and the translation equals the msgstr.
 
-        $faker = Factory::create();
         $catalogSource = new CatalogArray();
 
-        $translation = $faker->paragraph(5);
+        $translation = 'Test string';
 
         $entry = EntryFactory::createFromArray([
             'msgid' => $value,


### PR DESCRIPTION
This PR builds on https://github.com/pherrymason/PHP-po-parser/pull/103:

* drop support for PHP <8.3
* add types
* `declare(strict_types=1)`
* switch to short array syntax
* update dependencies to supported versions